### PR TITLE
Update 2025.0.0

### DIFF
--- a/.cursor/rules/cli-standards.mdc
+++ b/.cursor/rules/cli-standards.mdc
@@ -1,0 +1,22 @@
+---
+description: command-line interface standards
+alwaysApply: false
+---
+- MUST accept text input via stdin, arguments or files.
+- MUST accept environment variables for configuration, unless user opts out.
+- Sensitive data must use environment variables.
+- Environment variable names MUST use a project prefix [A-Z][A-Z0-9_]*_ (e.g., SPLURGE_DSV_).
+- Provide --output-format {table,json, and/or ndjson} (default: table).
+- When reading from stdin, a file path of - MUST mean “read from stdin”.
+- Stdout and stderr MUST be UTF-8 encoded without BOM.
+- Exit codes: 0 success; 1 generic error; 2 invalid arguments; 130 interrupted (Ctrl+C).
+- Flags map by prefix + uppercasing + hyphens→underscores (e.g., --api-token → SPLURGE_DSV_API_TOKEN).
+- JSON output formats:
+  - `--output-format json`: Output complete JSON arrays, one per line
+  - `--output-format ndjson`: Output one JSON object per line (newline-delimited)
+  - Never mix JSON with other text on stdout
+- If an env var is referenced but missing, fail fast: “Missing required environment variable: <NAME>”. 
+- Redact sensitive data for output, logging, and errors.
+- Document defaults in --help output.
+- CLI arguments override environment variables.
+- Environment variables override built-in defaults.

--- a/.cursor/rules/design-standards.mdc
+++ b/.cursor/rules/design-standards.mdc
@@ -1,0 +1,27 @@
+---
+description: code structure and design standards
+alwaysApply: false
+---
+- Follow SOLID (Single Responsibility, Open-Closed, Liskov Substitution, Interface Segregation, Dependency Inversion) principles.
+- Follow DRY (Don't Repeat Yourself) principle.
+- Follow BDD/TDD (Behavior/Test Driven Development) practices.
+- Follow MVP (Minimum Viable Product) approach.
+- Follow KISS (Keep It Simple, Stupid) principle.
+- Follow PoLA (Principle of Least Authority).
+- Follow YAGNI (You Aren't Gonna Need It) principle.
+- Prefer composition over inheritance.
+- Prefer encapsulation.
+- Prefer separation of concerns.
+- Prefer to fail fast.
+- Follow the Law of Demeter - objects should only interact with their immediate dependencies.
+- Prioritize error handling using appropriate mechanisms (exceptions, return values, Result types, or callbacks).
+- Use guard clauses to handle preconditions and invalid state early.
+- Avoid side effects in module-level code.
+- Place the happy path (main successful execution flow) last in the function.
+- Use guard clauses and early returns instead of complex if-else chains.
+- Prefer iteration and modularization over code duplication.
+- Prefer simple, straightforward design over over-engineering.
+- Private methods should accept necessary data as parameters rather than directly accessing instance variables.
+- Use domain-specific custom exceptions for public APIs.
+- Use native/built-in exceptions for low-level APIs, where appropriate.
+- Prioritize code clarity while maintaining reasonable efficiency.

--- a/.cursor/rules/documentation-standards.mdc
+++ b/.cursor/rules/documentation-standards.mdc
@@ -1,0 +1,22 @@
+---
+description: comments and documentation standards
+alwaysApply: false
+---
+- Add comments before complex logic blocks to explain the "why" and "what".
+- Use inline comments sparingly, only for complex or non-obvious code sections.
+- Remove outdated comments during refactoring instead of accumulating them.
+- Use Google-style docstrings for all public functions, classes, and modules in Python:
+  ```python
+  def process_data(input_file: str) -> dict:
+      """Process input file and return structured data.
+
+      Args:
+          input_file: Path to the input file to process
+
+      Returns:
+          Dictionary containing processed data
+
+      Raises:
+          FileNotFoundError: If input file doesn't exist
+      """
+  ```

--- a/.cursor/rules/method-standards.mdc
+++ b/.cursor/rules/method-standards.mdc
@@ -1,0 +1,24 @@
+---
+description: method signatures and parameter standards
+alwaysApply: false
+---
+- Prefer parameters in method signatures and method calls to be listed on separate lines.
+- Prefer named keywords for default parameters.
+- Method signatures shall prefer use of keywords for more than 1 parameter.
+- For method signatures with more than 2 parameters, place each parameter on a separate line:
+  ```python
+  def process_data(
+      input_file: str,
+      output_format: str,
+      validate_schema: bool = True
+  ) -> dict:
+  ```
+- For method calls with more than 2 parameters, place each parameter on a separate line:
+  ```python
+  result = process_data(
+      input_file="data.json",
+      output_format="ndjson",
+      validate_schema=True
+  )
+  ```
+- When updating a method or class signature, do not maintain backwards compatibility unless specifically told to do so.

--- a/.cursor/rules/naming-standards.mdc
+++ b/.cursor/rules/naming-standards.mdc
@@ -1,0 +1,11 @@
+---
+description: naming conventions
+alwaysApply: false
+---
+- Use descriptive variable names with auxiliary verbs (e.g. is_active, has_permission).
+- Use PascalCase for class, enum, and dataclass names (e.g., DsvReader, CsvWriter, TransformXmlToJson).
+- For SQL, prefer lower case column names.
+- Prefer upper snake case for constant names.
+- Environment variable names MUST use a project prefix [A-Z][A-Z0-9_]*_ (e.g., SPLURGE_DSV_).
+- Test module names should mirror the domains associated with the modules, where DOMAINS is a list of the module's domain names.
+ - e.g., for a module that has DOMAINS = ['dsv', 'csv'], the test module should be named test_csv_dsv_[SEQUENCE].py, where [SEQUENCE] is a unique identifier for the test module.

--- a/.cursor/rules/project-standards.mdc
+++ b/.cursor/rules/project-standards.mdc
@@ -1,0 +1,15 @@
+---
+description: project organization and standards
+alwaysApply: false
+---
+- Create top-level folder: docs/.
+- Create project README.md which summarizes the project.
+- Create project CHANGELOG.md which details changes for each version/feature-branch.
+- Create docs/README-DETAILS.md which details project features, usage, errors, dependencies, etc.
+- For code projects, create top-level folders: tests/, examples/, specs/.
+- For code projects, create sub-folders under tests/: unit/, integration/, e2e/.
+- For Python projects, create modern, standardized pyproject.toml.
+- For Python projects, use CalVer versioning.
+- License shall be MIT.
+- Author and Maintainer shall be Jim Schilling.
+- Project base url shall be http://github.com/jim-schilling/[REPOSITORY].

--- a/.cursor/rules/python-standards.mdc
+++ b/.cursor/rules/python-standards.mdc
@@ -1,0 +1,33 @@
+---
+description: modern python standards
+alwaysApply: false
+---
+- Always add type annotations to function and method signatures.
+- Add type annotations to variables when it improves code clarity.
+- Prefer | instead of Optional or Union.
+- Code concise, technical, Python that adheres to PEP 8 and PEP 585.
+- Code to modern Python standards targeting version 3.10 or later.
+- Use absolute import paths.
+- When possible, place imports at top of module.
+- Group and sort imports: standard libraries, then third-party libraries, then local libraries. Sort alphabetically within each group.
+- Use separate statements for multiple context managers instead of nesting them.
+- Use mypy for type validation.
+- Use ruff for style, formatting, and security validation.
+- Place module-level constants in UPPER_SNAKE_CASE.
+- Place a single space before and after operators (=, +, -, *, /, ==, !=, <, >, <=, >=, etc.).
+- Place a single space after commas in lists, tuples, and function parameters.
+- Use 4 spaces for indentation, no tabs.
+- Use UTF-8 encoding without BOM for all text files.
+- Use f-strings for string interpolation.
+- Use triple double quotes for docstrings and comments.
+- Use single quotes for string literals, except when the string contains single quotes.
+- Add a DOMAINS list at the top of each module indicating associated domains (e.g., DOMAINS = ["generator", "helpers"]).
+- Add a package level constant __domains__ listing all associated domains for the package in __init__.py.
+- Use exceptions for error handling, not return codes.
+- Use __all__ to define public API of modules.
+- Use logging module for logging, not print statements.
+- Use pathlib for file and path operations.
+- Use context managers for file operations.
+- Use list comprehensions and generator expressions for creating lists and iterators.
+- Use enumerate() when needing both index and value in loops.
+- Use zip() to iterate over multiple iterables in parallel.

--- a/.cursor/rules/sdlc-standards.mdc
+++ b/.cursor/rules/sdlc-standards.mdc
@@ -1,0 +1,17 @@
+---
+description: software development lifecycle standards
+alwaysApply: true
+---
+- Follow Research, Plan, and Implement lifecycle.- Document research in docs/research/research-[yyyy-MM-dd]-[sequence].md.
+- Document action plans in docs/plans/plan-[yyyy-MM-dd]-[sequence].md.
+- Document requirements and specifications in docs/specs/spec-[yyyy-MM-dd]-[sequence].md.
+- Document issues/bugs in docs/issues/issue-[yyyy-MM-dd]-[sequence].md.
+- Research shall include exploration of existing solutions, libraries, and tools.
+- Plans shall detail requirements, acceptance criteria, testing strategy (e.g. TDD and BDD), and a step-by-step implementation guide.
+- Each action plan shall be sub-divided into stages (e.g. Stage-1, Stage-2), while stages are subdivided into tasks (e.g. Task-[Stage].1, Task-[Stage].2).
+- Implementation lifecycle shall always: code failing tests, then implement code, then run tests, then iteratively refactor and run tests until all tests pass.
+- Every feature must start as a standalone library before integration:
+  - Develop features as independent, reusable library components first
+  - Only integrate into larger applications after proving standalone functionality
+- Software tools, primary libraries, data tools, and development tools must expose their functionality through a CLI. Other software functionality may omit a CLI if appropriate.
+- If in doubt, prompt user for clarification and mark as [NEEDS CLARIFICATION].

--- a/.cursor/rules/security-standards.mdc
+++ b/.cursor/rules/security-standards.mdc
@@ -1,0 +1,18 @@
+---
+description: secure coding standards and best practices
+alwaysApply: false
+---
+- Follow secure coding best practices.
+- Validate and sanitize all user inputs to prevent injection attacks (SQL, Shell, XSS, command injection).
+- Use parameterized queries and prepared statements for database operations.
+- Implement proper authentication and authorization mechanisms.
+- Never store sensitive data (passwords, API keys, tokens) in plain text.
+- Follow the principle of least privilege for user permissions and API access.
+- Implement comprehensive error handling without exposing sensitive information.
+- Restrict allowed file types and sizes.
+- Use secure random number generators for cryptographic operations.
+- Implement proper logging without logging sensitive information.
+- Follow OWASP security guidelines and address common vulnerabilities.
+- Use environment variables or secure vaults for configuration secrets.
+- Implement proper password policies and secure password hashing.
+- Follow secure API design principles (proper HTTP methods, versioning, etc.).

--- a/.cursor/rules/style-standards.mdc
+++ b/.cursor/rules/style-standards.mdc
@@ -1,0 +1,10 @@
+---
+description: code formatting and style standards
+alwaysApply: false
+---
+- Prefer line length max of 120 characters, except for tests or when to do so would require use of temporary variables.
+- Except clauses shall be prefixed with a blank line.
+- Prefer separating logical blocks of code with a blank line for visual clarity.
+- For Python, for any line continuations, use parentheses only.
+- For Python, use ruff for code style, linting, and formatting.
+- Avoid magic strings and magic numbers, instead prefer class level constants, otherwise use module/function level constants. 

--- a/.cursor/rules/testing-standards.mdc
+++ b/.cursor/rules/testing-standards.mdc
@@ -1,0 +1,29 @@
+---
+description: testing standards
+alwaysApply: false
+---
+- Validate behavior of public APIs only.
+- Prefer validation using actual data, interfaces, and objects
+- Avoid or minimize use of mocks, except where appropriate.
+- Target 85% code coverage for all public interfaces and methods.
+- Prefer shared helpers for common logic.
+- Avoid validation of implementation details and private APIs.
+- Prefer validation of patterns of text, and avoid exact matching of content and formatting.
+- Prefer pytest with pytest-xdist for testing with default parameters of -x -v -n auto.
+- Prefer pytest-cov for code coverage with parameters --cov=your_package --cov-report=term-missing.
+- Run pytest with code coverage when asked by user, otherwise skip.
+- Prefer pytest-mock for mocking, where appropriate.
+- Place unit tests in tests/unit/ and integration tests in tests/integration/, e2e tests in tests/e2e/, and performance tests in tests/performance/.
+- Place test data in tests/data.
+- For Python, prefer pure pytest function style tests.
+- For Python, prefer use of tmp_path and tmp_path_factory fixtures for temporary files and directories.
+- Name test methods as test_[condition]_[expectedResult].
+- Each test method should ideally test a single condition and expected result.
+- Use fixtures for common setup and teardown logic.
+- Use parameterized tests for testing multiple input scenarios.
+- Use assertions to validate expected outcomes.
+- Prefer tests/unit/* to run to completion within 60 seconds.
+- Prefer tests/integration/* to run to completion within 45 seconds.
+- Prefer tests/e2e/* to run to run to completion within 45 seconds.
+- Prefer tests/performance/* to run to completion within 45 seconds.
+- Prefer entire test suite to run to completion within 120 seconds.

--- a/.github/badges/coverage.json
+++ b/.github/badges/coverage.json
@@ -1,0 +1,1 @@
+{"schemaVersion":1,"label":"coverage","message":"unknown","color":"lightgrey"}

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,216 @@
+# GitHub Copilot Instructions
+
+This document contains coding standards and guidelines for the splurge-ai-rules project. These instructions help maintain consistency and quality across the codebase.
+
+## Software Development Lifecycle Standards
+- Follow Research, Plan, and Implement lifecycle.
+- Document research in docs/research/research-[yyyy-MM-dd]-[sequence].md.
+- Document action plans in docs/plans/plan-[yyyy-MM-dd]-[sequence].md.
+- Document requirements and specifications in docs/specs/spec-[yyyy-MM-dd]-[sequence].md.
+- Document issues/bugs in docs/issues/issue-[yyyy-MM-dd]-[sequence].md.
+- Research shall include exploration of existing solutions, libraries, and tools.
+- Plans shall detail requirements, acceptance criteria, testing strategy (e.g. TDD and BDD), and a step-by-step implementation guide.
+- Each action plan shall be sub-divided into stages (e.g. Stage-1, Stage-2), while stages are subdivided into tasks (e.g. Task-[Stage].1, Task-[Stage].2).
+- Implementation lifecycle shall always: code failing tests, then implement code, then run tests, then iteratively refactor and run tests until all tests pass.
+- Every feature must start as a standalone library before integration:
+  - Develop features as independent, reusable library components first
+  - Only integrate into larger applications after proving standalone functionality
+- Software tools, primary libraries, data tools, and development tools must expose their functionality through a CLI. Other software functionality may omit a CLI if appropriate.
+- If in doubt, prompt user for clarification and mark as [NEEDS CLARIFICATION].
+- Always ask for user confirmation before making significant changes.
+- Always ask for user confirmation before deleting files or data.
+- Always ask for user confirmation before overwriting existing files.
+- Use git for version control with feature branches and pull requests.
+- Write clear, concise commit messages in the imperative mood (e.g., "Add feature", "Fix bug").
+
+## Project Organization Standards
+- Create top-level folder: docs/.
+- Create project README.md which summarizes the project.
+- Create project CHANGELOG.md which details changes for each version/feature-branch.
+- Create docs/README-DETAILS.md which details project features, usage, errors, dependencies, etc.
+- Create sub-folders under docs/: research/, plans/, specs/, issues/.
+- For code projects, create top-level folders: tests/, examples/, specs/.
+- For code projects, create sub-folders under tests/: unit/, integration/, e2e/.
+- For Python projects, create modern, standardized pyproject.toml.
+- For Python projects, use CalVer versioning.
+- License shall be MIT.
+- Author and Maintainer shall be Jim Schilling.
+- Project base url shall be http://github.com/jim-schilling/[REPOSITORY].
+
+## Design Standards
+- Follow SOLID (Single Responsibility, Open-Closed, Liskov Substitution, Interface Segregation, Dependency Inversion) principles.
+- Follow DRY (Don't Repeat Yourself) principle.
+- Follow BDD/TDD (Behavior/Test Driven Development) practices.
+- Follow MVP (Minimum Viable Product) approach.
+- Follow KISS (Keep It Simple, Stupid) principle.
+- Follow PoLA (Principle of Least Authority).
+- Follow YAGNI (You Aren't Gonna Need It) principle.
+- Prefer composition over inheritance.
+- Prefer encapsulation.
+- Prefer separation of concerns.
+- Prefer to fail fast.
+- Follow the Law of Demeter - objects should only interact with their immediate dependencies.
+- Prioritize error handling using appropriate mechanisms (exceptions, return values, Result types, or callbacks).
+- Use guard clauses to handle preconditions and invalid state early.
+- Avoid side effects in module-level code.
+- Place the happy path (main successful execution flow) last in the function.
+- Use guard clauses and early returns instead of complex if-else chains.
+- Prefer iteration and modularization over code duplication.
+- Prefer simple, straightforward design over over-engineering.
+- Private methods should accept necessary data as parameters rather than directly accessing instance variables.
+- Use domain-specific custom exceptions for public APIs.
+- Use native/built-in exceptions for low-level APIs, where appropriate.
+- Prioritize code clarity while maintaining reasonable efficiency.
+
+## Python Standards
+- Always add type annotations to function and method signatures.
+- Add type annotations to variables when it improves code clarity.
+- Prefer | instead of Optional or Union.
+- Code concise, technical, Python that adheres to PEP 8 and PEP 585.
+- Code to modern Python standards targeting version 3.10 or later.
+- Use absolute import paths.
+- When possible, place imports at top of module.
+- Group and sort imports: standard libraries, then third-party libraries, then local libraries. Sort alphabetically within each group.
+- Use separate statements for multiple context managers instead of nesting them.
+- Use mypy for type validation.
+- Use ruff for style, formatting, and security validation.
+- Place module-level constants in UPPER_SNAKE_CASE.
+- Place a single space before and after operators (=, +, -, *, /, ==, !=, <, >, <=, >=, etc.).
+- Place a single space after commas in lists, tuples, and function parameters.
+- Use 4 spaces for indentation, no tabs.
+- Use UTF-8 encoding without BOM for all text files.
+- Use f-strings for string interpolation.
+- Use triple double quotes for docstrings and comments.
+- Use single quotes for string literals, except when the string contains single quotes.
+- Add a DOMAINS list at the top of each module indicating associated domains (e.g., DOMAINS = ["generator", "helpers"]).
+- Add a package level constant __domains__ listing all associated domains for the package in __init__.py.
+- Use exceptions for error handling, not return codes.
+- Use __all__ to define public API of modules.
+- Use logging module for logging, not print statements.
+- Use pathlib for file and path operations.
+- Use context managers for file operations.
+- Use list comprehensions and generator expressions for creating lists and iterators.
+- Use enumerate() when needing both index and value in loops.
+- Use zip() to iterate over multiple iterables in parallel.
+
+## Naming Standards
+- Use descriptive variable names with auxiliary verbs (e.g. is_active, has_permission).
+- Use PascalCase for class, enum, and dataclass names (e.g., DsvReader, CsvWriter, TransformXmlToJson).
+- For SQL, prefer lower case column names.
+- Prefer upper snake case for constant names.
+- Environment variable names MUST use a project prefix [A-Z][A-Z0-9_]*_ (e.g., SPLURGE_DSV_).
+- Test module names should mirror the domains associated with the modules, where DOMAINS is a list of the module's domain names.
+ - e.g., for a module that has DOMAINS = ['dsv', 'csv'], the test module should be named test_csv_dsv_[SEQUENCE].py, where [SEQUENCE] is a unique identifier for the test module.
+
+## Method Standards
+- Prefer parameters in method signatures and method calls to be listed on separate lines.
+- Prefer named keywords for default parameters.
+- Method signatures shall prefer use of keywords for more than 1 parameter.
+- For method signatures with more than 2 parameters, place each parameter on a separate line:
+  ```python
+  def process_data(
+      input_file: str,
+      output_format: str,
+      validate_schema: bool = True
+  ) -> dict:
+  ```
+- For method calls with more than 2 parameters, place each parameter on a separate line:
+  ```python
+  result = process_data(
+      input_file="data.json",
+      output_format="ndjson",
+      validate_schema=True
+  )
+  ```
+- When updating a method or class signature, do not maintain backwards compatibility unless specifically told to do so.
+
+## Style Standards
+- Prefer line length max of 120 characters in code modules, except for tests or when to do so would require use of temporary variables.
+- Except clauses shall be prefixed with a blank line.
+- Prefer separating logical blocks of code with a blank line for visual clarity.
+- For Python, for any line continuations, use parentheses only.
+- For Python, use ruff for code style, linting, and formatting.
+- Avoid magic strings and magic numbers, instead prefer class level constants, otherwise use module/function level constants.
+
+## Documentation Standards
+- Add comments before complex logic blocks to explain the "why" and "what".
+- Use inline comments sparingly, only for complex or non-obvious code sections.
+- Remove outdated comments during refactoring instead of accumulating them.
+- Use Google-style docstrings for all public functions, classes, and modules in Python:
+  ```python
+  def process_data(input_file: str) -> dict:
+      """Process input file and return structured data.
+
+      Args:
+          input_file: Path to the input file to process
+
+      Returns:
+          Dictionary containing processed data
+
+      Raises:
+          FileNotFoundError: If input file doesn't exist
+      """
+  ```
+
+## Testing Standards
+- Validate behavior of public APIs only.
+- Prefer validation using actual data, interfaces, and objects
+- Avoid or minimize use of mocks, except where appropriate.
+- Target 85% code coverage for all public interfaces and methods.
+- Prefer shared helpers for common logic.
+- Avoid validation of implementation details and private APIs.
+- Prefer validation of patterns of text, and avoid exact matching of content and formatting.
+- Prefer pytest with pytest-xdist for testing with default parameters of -x -v -n auto.
+- Prefer pytest-cov for code coverage with parameters --cov=your_package --cov-report=term-missing.
+- Prefer pytest-mock for mocking, where appropriate.
+- Run pytest with code coverage when asked by user, otherwise skip.
+- Place unit tests in tests/unit/ and integration tests in tests/integration/, e2e tests in tests/e2e/, and performance tests in tests/performance/.
+- Place test data in tests/data.
+- For Python, prefer pure pytest function style tests.
+- For Python, prefer use of tmp_path and tmp_path_factory fixtures for temporary files and directories.
+- Name test methods as test_[condition]_[expectedResult].
+- Each test method should ideally test a single condition and expected result.
+- Use fixtures for common setup and teardown logic.
+- Use parameterized tests for testing multiple input scenarios.
+- Use assertions to validate expected outcomes.
+- Prefer tests/unit/* to run to completion within 60 seconds.
+- Prefer tests/integration/* to run to completion within 60 seconds.
+- Prefer tests/e2e/* to run to run to completion within 60 seconds.
+- Prefer tests/performance/* to run to completion within 60 seconds.
+- Prefer entire test suite to run to completion within 120 seconds.
+
+## CLI Standards
+- MUST accept text input via stdin, arguments or files.
+- MUST accept environment variables for configuration, unless user opts out.
+- Sensitive data must use environment variables.
+- Environment variable names MUST use a project prefix [A-Z][A-Z0-9_]*_ (e.g., SPLURGE_DSV_).
+- Provide --output-format {table,json, and/or ndjson} (default: table).
+- When reading from stdin, a file path of - MUST mean "read from stdin".
+- Stdout and stderr MUST be UTF-8 encoded without BOM.
+- Exit codes: 0 success; 1 generic error; 2 invalid arguments; 130 interrupted (Ctrl+C).
+- Flags map by prefix + uppercasing + hyphens→underscores (e.g., --api-token → SPLURGE_DSV_API_TOKEN).
+- JSON output formats:
+  - `--output-format json`: Output complete JSON arrays, one per line
+  - `--output-format ndjson`: Output one JSON object per line (newline-delimited)
+  - Never mix JSON with other text on stdout
+- If an env var is referenced but missing, fail fast: "Missing required environment variable: <NAME>".
+- Redact sensitive data for output, logging, and errors.
+- Document defaults in --help output.
+- CLI arguments override environment variables.
+- Environment variables override built-in defaults.
+
+## Security Standards
+- Follow secure coding best practices.
+- Validate and sanitize all user inputs to prevent injection attacks (SQL, Shell, XSS, command injection).
+- Use parameterized queries and prepared statements for database operations.
+- Implement proper authentication and authorization mechanisms.
+- Never store sensitive data (passwords, API keys, tokens) in plain text.
+- Follow the principle of least privilege for user permissions and API access.
+- Implement comprehensive error handling without exposing sensitive information.
+- Restrict allowed file types and sizes.
+- Use secure random number generators for cryptographic operations.
+- Implement proper logging without logging sensitive information.
+- Follow OWASP security guidelines and address common vulnerabilities.
+- Use environment variables or secure vaults for configuration secrets.
+- Implement proper password policies and secure password hashing.
+- Follow secure API design principles (proper HTTP methods, versioning, etc.).

--- a/.github/workflows/ci-py-3.10.yml
+++ b/.github/workflows/ci-py-3.10.yml
@@ -1,0 +1,13 @@
+name: Python CI (3.10)
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  call-reusable:
+    uses: ./.github/workflows/ci-reusable.yml
+    with:
+      python-version: '3.10'

--- a/.github/workflows/ci-py-3.11.yml
+++ b/.github/workflows/ci-py-3.11.yml
@@ -1,0 +1,13 @@
+name: Python CI (3.11)
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  call-reusable:
+    uses: ./.github/workflows/ci-reusable.yml
+    with:
+      python-version: '3.11'

--- a/.github/workflows/ci-py-3.12.yml
+++ b/.github/workflows/ci-py-3.12.yml
@@ -1,0 +1,13 @@
+name: Python CI (3.12)
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  call-reusable:
+    uses: ./.github/workflows/ci-reusable.yml
+    with:
+      python-version: '3.12'

--- a/.github/workflows/ci-py-3.13.yml
+++ b/.github/workflows/ci-py-3.13.yml
@@ -1,0 +1,13 @@
+name: Python CI (3.13)
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  call-reusable:
+    uses: ./.github/workflows/ci-reusable.yml
+    with:
+      python-version: '3.13'

--- a/.github/workflows/ci-reusable.yml
+++ b/.github/workflows/ci-reusable.yml
@@ -1,0 +1,94 @@
+name: Reusable CI
+
+on:
+  workflow_call:
+    inputs:
+      python-version:
+        required: true
+        type: string
+    secrets:
+      CODECOV_TOKEN:
+        required: false
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ inputs.python-version }}
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ inputs.python-version }}-${{ hashFiles('pyproject.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-${{ inputs.python-version }}-
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements-dev.txt ]; then
+            pip install -r requirements-dev.txt
+          elif [ -f pyproject.toml ]; then
+            pip install -e '.[dev]' || pip install pytest pytest-cov
+          else
+            pip install pytest pytest-cov
+          fi
+      - name: Run pre-commit checks
+        run: |
+          pre-commit run --all-files || true
+      - name: Run tests with coverage
+        run: |
+          python -m pytest -q --cov=splurge_test_namer --cov-report=xml:coverage.xml --cov-report=html:htmlcov
+      - name: Upload coverage artifacts
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report-${{ inputs.python-version }}
+          path: |
+            coverage.xml
+            htmlcov
+      - name: Upload to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: coverage.xml
+      - name: Compute coverage percent
+        id: coverage
+        run: |
+          # extract line-rate from coverage.xml (coverage.py produces <coverage line-rate="0.94">)
+          if [ -f coverage.xml ]; then
+            pct=$(xmllint --xpath 'string(/coverage/@line-rate)' coverage.xml || true)
+            if [ -n "$pct" ]; then
+              # convert 0.94123 -> 94.12
+              pct100=$(awk -v v="$pct" 'BEGIN{printf("%.2f", v*100)}')
+              echo "coverage_percent=$pct100" >> $GITHUB_OUTPUT
+            else
+              echo "coverage_percent=unknown" >> $GITHUB_OUTPUT
+            fi
+          else
+            echo "coverage_percent=unknown" >> $GITHUB_OUTPUT
+          fi
+      - name: Update coverage badge JSON
+        run: |
+          pct=${{ steps.coverage.outputs.coverage_percent }}
+          color=lightgrey
+          if [ "$pct" != "unknown" ]; then
+            # choose color thresholds
+            color=red
+            if (( $(echo "$pct >= 90" | bc -l) )); then color=brightgreen; elif (( $(echo "$pct >= 75" | bc -l) )); then color=yellow; fi
+            msg="$pct%"
+          else
+            msg="unknown"
+          fi
+          jq -n --arg label "coverage" --arg message "$msg" --arg color "$color" '{schemaVersion:1, label:$label, message:$message, color:$color}' > .github/badges/coverage.json
+      - name: Commit coverage badge to main
+        if: github.ref == 'refs/heads/main' && github.actor != 'github-actions[bot]'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add .github/badges/coverage.json
+          git commit -m "Update coverage badge: ${{ steps.coverage.outputs.coverage_percent }}%" || echo "No changes to commit"
+          git push origin HEAD:main || echo "Push failed (likely due to permissions)"

--- a/.github/workflows/coverage-commit.yml
+++ b/.github/workflows/coverage-commit.yml
@@ -1,0 +1,61 @@
+name: Coverage Badge Commit
+
+on:
+  push:
+    branches: [ main ]
+
+permissions:
+  contents: write
+
+jobs:
+  coverage-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.12'
+      - name: Install deps
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
+      - name: Run tests with coverage
+        run: |
+          python -m pytest -q --cov=splurge_test_namer --cov-report=xml:coverage.xml --cov-report=html:htmlcov
+      - name: Compute coverage percent
+        id: coverage
+        run: |
+          if [ -f coverage.xml ]; then
+            # extract line-rate
+            pct=$(xmllint --xpath 'string(/coverage/@line-rate)' coverage.xml || true)
+            if [ -n "$pct" ]; then
+              pct100=$(awk -v v="$pct" 'BEGIN{printf("%.2f", v*100)}')
+              echo "coverage_percent=$pct100" >> $GITHUB_OUTPUT
+            else
+              echo "coverage_percent=unknown" >> $GITHUB_OUTPUT
+            fi
+          else
+            echo "coverage_percent=unknown" >> $GITHUB_OUTPUT
+          fi
+      - name: Update badge JSON
+        run: |
+          pct=${{ steps.coverage.outputs.coverage_percent }}
+          color=lightgrey
+          if [ "$pct" != "unknown" ]; then
+            color=red
+            if (( $(echo "$pct >= 90" | bc -l) )); then color=brightgreen; elif (( $(echo "$pct >= 75" | bc -l) )); then color=yellow; fi
+            msg="$pct%"
+          else
+            msg="unknown"
+          fi
+          mkdir -p .github/badges
+          jq -n --arg label "coverage" --arg message "$msg" --arg color "$color" '{schemaVersion:1, label:$label, message:$message, color:$color}' > .github/badges/coverage.json
+      - name: Commit and push badge
+        if: github.actor != 'github-actions[bot]'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add .github/badges/coverage.json
+          git commit -m "ci: update coverage badge to ${{ steps.coverage.outputs.coverage_percent }}%" || echo "no changes"
+          git push origin HEAD:main || echo "push failed"

--- a/.github/workflows/coverage-commit.yml
+++ b/.github/workflows/coverage-commit.yml
@@ -51,11 +51,13 @@ jobs:
           fi
           mkdir -p .github/badges
           jq -n --arg label "coverage" --arg message "$msg" --arg color "$color" '{schemaVersion:1, label:$label, message:$message, color:$color}' > .github/badges/coverage.json
-      - name: Commit and push badge
-        if: github.actor != 'github-actions[bot]'
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add .github/badges/coverage.json
-          git commit -m "ci: update coverage badge to ${{ steps.coverage.outputs.coverage_percent }}%" || echo "no changes"
-          git push origin HEAD:main || echo "push failed"
+      - name: Create PR with updated badge
+        uses: peter-evans/create-pull-request@v5
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "ci: update coverage badge to ${{ steps.coverage.outputs.coverage_percent }}%"
+          branch: "ci/coverage-badge-${{ github.run_id }}"
+          title: "ci: update coverage badge"
+          body: |
+            This PR updates the coverage badge based on the latest test run (coverage: ${{ steps.coverage.outputs.coverage_percent }}%).
+          labels: ci,coverage

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -1,0 +1,90 @@
+name: Python CI
+
+on:
+  push:
+    branches: [ main, 'update-*', '**' ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test-main:
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.10, 3.11, 3.12, 3.13]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('pyproject.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-${{ matrix.python-version }}-
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements-dev.txt ]; then
+            pip install -r requirements-dev.txt
+          elif [ -f pyproject.toml ]; then
+            pip install -e '.[dev]' || pip install pytest pytest-cov
+          else
+            pip install pytest pytest-cov
+          fi
+      - name: Run pre-commit checks
+        run: |
+          pre-commit run --all-files || true
+      - name: Run tests with coverage
+        run: python -m pytest -q
+      - name: Upload coverage report
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report-${{ matrix.python-version }}
+          path: .
+
+  test-feature:
+    if: github.ref != 'refs/heads/main'
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.12, 3.13]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('pyproject.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-${{ matrix.python-version }}-
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements-dev.txt ]; then
+            pip install -r requirements-dev.txt
+          elif [ -f pyproject.toml ]; then
+            pip install -e '.[dev]' || pip install pytest pytest-cov
+          else
+            pip install pytest pytest-cov
+          fi
+      - name: Run pre-commit checks
+        run: |
+          pre-commit run --all-files || true
+      - name: Run tests with coverage
+        run: python -m pytest -q
+      - name: Upload coverage report
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report-${{ matrix.python-version }}
+          path: .

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -40,13 +40,16 @@ jobs:
         run: |
           pre-commit run --all-files || true
       - name: Run tests with coverage
-        run: python -m pytest -q
-      - name: Upload coverage report
+        run: |
+          python -m pytest -q --cov=splurge_test_namer --cov-report=xml:coverage.xml --cov-report=html:htmlcov
+      - name: Upload coverage artifacts
         if: success()
         uses: actions/upload-artifact@v4
         with:
           name: coverage-report-${{ matrix.python-version }}
-          path: .
+          path: |
+            coverage.xml
+            htmlcov
 
   test-feature:
     if: github.ref != 'refs/heads/main'
@@ -81,10 +84,13 @@ jobs:
         run: |
           pre-commit run --all-files || true
       - name: Run tests with coverage
-        run: python -m pytest -q
-      - name: Upload coverage report
+        run: |
+          python -m pytest -q --cov=splurge_test_namer --cov-report=xml:coverage.xml --cov-report=html:htmlcov
+      - name: Upload coverage artifacts
         if: success()
         uses: actions/upload-artifact@v4
         with:
           name: coverage-report-${{ matrix.python-version }}
-          path: .
+          path: |
+            coverage.xml
+            htmlcov

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,24 @@
+repos:
+  - repo: local
+    hooks:
+      - id: ruff
+        name: ruff
+        # use the 'check' subcommand so the '--fix' flag is accepted by the installed ruff CLI
+        entry: ruff check --fix
+        language: system
+        files: "\\.py$"
+
+      - id: mypy
+        name: mypy
+        entry: mypy --ignore-missing-imports
+        language: system
+        files: "\\.py$"
+
+      - id: pytest
+        name: pytest
+        # run pytest as a module so the repository root is on sys.path and local package imports resolve
+        # ignore the repository pytest.ini here (-c /dev/null) and disable pytest-cov to avoid coverage file
+        # creation/combining which can be locked on Windows during pre-commit runs
+        entry: python -m pytest -q -p no:pytest_cov -c /dev/null
+        language: system
+        files: ^tests/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# 2025.0.0 - 2025-09-15
+
+- Added import-following mode: aggregate sentinels from imported modules under a root package.
+- Added CLI flags: `--root-import`, `--repo-root`, `--verbose`.
+- Improved API: parser.find_imports_in_file, parser.aggregate_sentinels_for_test, util_helpers.resolve_module_to_paths.
+- Added tests for import scanning, module resolution, and end-to-end naming.
+

--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
-# splurge-test-domain-namer
-Splurge Test Domain Namer Tool
+# splurge-test-namer
+
+A small tool to rename test modules based on module-level sentinel lists (e.g. `DOMAINS = ['core','utils']`).
+
+Usage
+-----
+- Dry run: `python -m splurge_test_namer.cli --root tests`
+- Apply renames: `python -m splurge_test_namer.cli --root tests --apply`
+- Follow imports under a root package: `python -m splurge_test_namer.cli --root tests --root-import splurge_sql_tool --repo-root /path/to/repo`
+
+New in 2025.0.0
+---------------
+- Import-following mode: aggregate sentinels from imported modules under a root package when proposing test filenames.
+- CLI flags: `--root-import`, `--repo-root`, `--verbose`.
+
+See `docs/README-DETAILS.md` for full API and design notes.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,16 @@
 
 A small tool to rename test modules based on module-level sentinel lists (e.g. `DOMAINS = ['core','utils']`).
 
+[![3.10](https://github.com/jim-schilling/splurge-test-namer/actions/workflows/ci-py-3.10.yml/badge.svg)](https://github.com/jim-schilling/splurge-test-namer/actions/workflows/ci-py-3.10.yml)
+[![3.11](https://github.com/jim-schilling/splurge-test-namer/actions/workflows/ci-py-3.11.yml/badge.svg)](https://github.com/jim-schilling/splurge-test-namer/actions/workflows/ci-py-3.11.yml)
+[![3.12](https://github.com/jim-schilling/splurge-test-namer/actions/workflows/ci-py-3.12.yml/badge.svg)](https://github.com/jim-schilling/splurge-test-namer/actions/workflows/ci-py-3.12.yml)
+[![3.13](https://github.com/jim-schilling/splurge-test-namer/actions/workflows/ci-py-3.13.yml/badge.svg)](https://github.com/jim-schilling/splurge-test-namer/actions/workflows/ci-py-3.13.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+[![ruff](https://img.shields.io/badge/ruff-checks-green.svg)](https://github.com/jim-schilling/splurge-test-namer/actions)
+[![mypy](https://img.shields.io/badge/mypy-passed-brightgreen.svg)](https://github.com/jim-schilling/splurge-test-namer/actions)
+[![coverage](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/jim-schilling/splurge-test-namer/main/.github/badges/coverage.json)](https://github.com/jim-schilling/splurge-test-namer/actions)
+[![PyPI version](https://img.shields.io/pypi/v/splurge-test-namer.svg)](https://pypi.org/project/splurge-test-namer)
+
 Usage
 -----
 - Dry run: `python -m splurge_test_namer.cli --root tests`

--- a/docs/README-DETAILS.md
+++ b/docs/README-DETAILS.md
@@ -1,0 +1,84 @@
+# Details — splurge-test-namer
+
+This document describes features, APIs, errors, and usage of the splurge-test-namer tool.
+
+Features
+--------
+- Rename test modules based on module-level sentinel lists (default sentinel: `DOMAINS`).
+- Optional import-following mode: when provided a `root_import` (e.g. `splurge_sql_tool`) and `repo_root`, the tool scans test files for imports that begin with the `root_import`, resolves those module names to files inside `repo_root`, reads their sentinel lists, aggregates them, and uses the aggregated set to form the test filename prefix.
+- Deterministic naming and sequence assignment.
+- Dry-run mode by default; `--apply` performs actual rename operations.
+- `--verbose` flag enables debug logging.
+
+APIs / Functions
+----------------
+- parser.find_imports_in_file(path: Path, root_import: str) -> set[str]
+  - Parse AST for `Import` and `ImportFrom` nodes and return imports beginning with `root_import`.
+
+- util_helpers.resolve_module_to_paths(module_name: str, repo_root: Path) -> list[Path]
+  - Resolve dotted module names to candidate file paths (module.py and package/__init__.py) inside repo_root.
+
+- parser.aggregate_sentinels_for_test(test_path: Path, root_import: str, repo_root: Path, sentinel_name: str = 'DOMAINS') -> list[str]
+  - Aggregate sentinel lists from resolved modules imported by a test file and return a sorted unique list.
+
+- namer.build_proposals(root: Path, sentinel: str = 'DOMAINS', root_import: str | None = None, repo_root: Path | None = None) -> list[tuple[Path, Path]]
+  - Build rename proposals; use import-following aggregation when `root_import` and `repo_root` are provided.
+
+Errors and Logging
+------------------
+- Custom exceptions are defined in `splurge_test_namer.exceptions` (e.g., `FileReadError`, `FileRenameError`, `SentinelReadError`, `SplurgeTestNamerError`).
+- Unresolvable imports or missing modules emit debug/info logs and do not abort the run.
+- Use `--verbose` to enable debug logging.
+
+CLI
+---
+- `--root`: tests root to scan (default: `tests`)
+- `--apply`: apply renames (default: dry-run)
+- `--sentinel`: sentinel variable name (default: `DOMAINS`)
+- `--root-import`: root import package to follow (optional)
+- `--repo-root`: filesystem path to repository root for resolving imports (optional)
+- `-v/--verbose`: enable verbose debug logging
+
+Notes
+-----
+- The tool only resolves modules within `repo_root`. External packages (site-packages) are ignored.
+- Dynamic or runtime imports are out-of-scope.
+
+Developer setup
+---------------
+To set up a local development environment and enable pre-commit hooks, run the following (Windows bash example):
+
+1. Create and activate a virtual environment (Windows bash):
+
+```bash
+python -m venv .venv
+source .venv/Scripts/activate
+```
+
+2. Install pinned development dependencies:
+
+```bash
+python -m pip install --upgrade pip
+pip install -r ../requirements-dev.txt
+```
+
+3. Install pre-commit hooks:
+
+```bash
+pre-commit install
+```
+
+After this, commits will run configured checks (ruff, mypy, pytest) on changed files. You can run the full pre-commit suite locally with:
+
+```bash
+pre-commit run --all-files
+```
+
+If you prefer to install from the project metadata instead of the pinned file, you can run:
+
+```bash
+pip install -e '.[dev]'
+```
+
+
+

--- a/docs/plans/plan-import-scan-2025-sep-15.md
+++ b/docs/plans/plan-import-scan-2025-sep-15.md
@@ -1,0 +1,94 @@
+# Plan: Import-following sentinel scan
+
+Date: 2025-09-15
+Author: automated plan generator
+
+Summary
+-------
+Add an optional import-following mode to the test renamer tool. When provided a root import path (for example `splurge_sql_tool`), the tool will scan test modules for imports that start with that root, resolve those imported modules to repository file paths, extract module-level sentinel lists from the imported modules, aggregate the sentinels into a deterministic sorted set, and use that set to generate test filename prefixes.
+
+Goals
+-----
+- Accept a `root_import` parameter (CLI and programmatic API).
+- For each test module, find all imports whose module path starts with `root_import`.
+- Resolve those imported module names to filesystem paths within the repository workspace (support `package.__init__.py` and `module.py`).
+- Read sentinel lists from the resolved module files and aggregate them per test file.
+- Create a sorted, deduplicated sentinel list per test and use it to build file-name prefixes (e.g. `test_core_0001.py`, `test_sql_utils_0003.py`).
+- Ensure unit and integration test filenames follow the same naming logic (e.g. `test_cli_0001.py`, `test_utils_0003.py`) when the repository under test uses the sentinel system.
+- Keep behaviour backward-compatible when `root_import` is not provided.
+
+Brief API (function signatures)
+-------------------------------
+- parser.find_imports_in_file(path: Path, root_import: str) -> set[str]
+  - Parse AST of `path` and return dotted module names imported that start with `root_import`.
+  - Example: from `tests/test_x.py` containing `from splurge_sql_tool.core import Query`, returns `{"splurge_sql_tool.core"}`.
+
+- util_helpers.resolve_module_to_paths(module_name: str, repo_root: Path) -> list[Path]
+  - Given a dotted module name, return candidate file paths in the repo (e.g., `splurge_sql_tool/core.py`, `splurge_sql_tool/core/__init__.py`).
+  - Returns an empty list if none found.
+
+- parser.aggregate_sentinels_for_test(test_path: Path, root_import: str, repo_root: Path, sentinel_name: str = "DOMAINS") -> list[str]
+  - Find imports in `test_path` matching `root_import`, resolve each import to file(s), read sentinel lists from each resolved module, produce a sorted unique list of sentinels.
+  - This will call `read_sentinels_from_file` for each resolved module file and aggregate results.
+
+- namer.build_proposals(root: Path, sentinel: str = "DOMAINS", root_import: str | None = None, repo_root: Path | None = None) -> list[tuple[Path, Path]]
+  - When `root_import` is provided, call `parser.aggregate_sentinels_for_test` per test file to build the prefix.
+  - `repo_root` is used to resolve module import names to filesystem paths; default is project repository root.
+
+Data shapes and behaviour contract
+---------------------------------
+- Inputs:
+  - `root`: Path to tests directory to scan.
+  - `root_import`: dotted root package string (optional).
+  - `sentinel`: module-level variable name to read (default `DOMAINS`).
+  - `repo_root`: repository root path for resolving imports.
+- Outputs:
+  - `build_proposals` returns list of tuples (original_path, proposed_path).
+- Error modes:
+  - Missing `repo_root` or test `root` -> `SystemExit(1)` via CLI; programmatic API should raise `SplurgeTestNamerError`.
+  - Unresolvable module names -> ignored with a logged warning; continue.
+  - Files with invalid syntax when reading sentinels -> skip that module and log warning; treat as no sentinels.
+- Determinism:
+  - Sorting rules: file discovery uses sorted list from rglob; import lists are sorted lexicographically; aggregated sentinel lists sorted alphabetically.
+  - Sequence numbers are assigned in deterministic order per prefix across the whole scan.
+
+Edge cases and handling
+-----------------------
+- Aliased imports (e.g., `import splurge_sql_tool as s`) — only the real dotted name is relevant; detect `Import` nodes and consider `name` attributes.
+- `from splurge_sql_tool import core` and `from splurge_sql_tool.core import Query` — handle both `ImportFrom` and `Import` forms; reconstruct full module names.
+- Multi-level imports (e.g., `from splurge_sql_tool.subpkg import module as m`) — use the full dotted path that starts with `root_import`.
+- Wildcard imports (e.g., `from splurge_sql_tool.core import *`) — treat like `from splurge_sql_tool.core import` and resolve `splurge_sql_tool.core`.
+- Dynamic imports (e.g., `importlib.import_module('splurge_sql_tool.' + mod)`) — ignore dynamic imports; they are out-of-scope.
+- Missing modules on disk -> log a warning and continue; do not fail the entire run.
+- Circular imports between modules -> resolution only follows module names statically; do not execute import logic or attempt to traverse import graphs beyond direct imports found in the test file.
+- Packages vs modules -> prefer `module.py`, then `module/__init__.py`.
+- Tests importing modules from virtualenv/external packages -> try to resolve within `repo_root` first; if not found, skip (we only care about code in the repository).
+- Duplicate sentinel entries across multiple resolved modules -> dedupe and sort.
+
+Acceptance criteria
+-------------------
+- Unit tests exist for `parser.find_imports_in_file` that cover `Import` and `ImportFrom` forms (aliases, `as` names, wildcard) and return only imports starting with `root_import`.
+- Unit tests exist for `util_helpers.resolve_module_to_paths` validating resolution to `module.py` and `module/__init__.py` for packages and returning empty list for non-existent modules.
+- Integration test: small simulated repo under `tmp_path` with package `splurge_sql_tool` having `core.py` and `utils.py`, tests importing those modules. Running `build_proposals` with `root_import='splurge_sql_tool'` produces proposals that include prefixes built from sentinels aggregated across imported modules.
+ - Tests (unit and integration) should be named using the same sentinel-based naming rules when applicable; test fixtures used to simulate repositories should demonstrate that naming produces `test_<sentinels>_NNNN.py` style filenames.
+- Behavior is backward-compatible when `root_import` omitted: the tool falls back to reading sentinels from the test module itself.
+- Logged warnings for unresolvable modules appear but do not abort the run.
+
+Testing strategy
+----------------
+- Use pytest with `tmp_path` fixtures to create small package trees.
+- Tests:
+  - Unit tests for AST import parsing — feed small source strings, parse, and assert expected module names.
+  - Unit tests for module resolution — create files under `tmp_path`, call resolver, assert found paths.
+  - Integration end-to-end test — write test file under `tmp_path/tests/` importing repo modules and ensure `build_proposals` returns deterministic proposals.
+- Run tests locally with `pytest -q`.
+
+Notes and next steps
+--------------------
+1. Implement `parser.find_imports_in_file` and unit tests.
+2. Implement `util_helpers.resolve_module_to_paths`.
+3. Implement `parser.aggregate_sentinels_for_test` using the existing `read_sentinels_from_file`.
+4. Update `namer.build_proposals` to accept `root_import` and `repo_root` and use aggregated sentinels.
+5. Add `--root-import` CLI flag to `cli.py` and update help documentation.
+
+If you want, I can start implementing step 2 (add import scanner in `parser.py`) and mark that todo `in-progress`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,34 @@
+[project]
+name = "splurge-test-namer"
+version = "2025.0.0"
+description = "Rename test modules based on sentinel metadata and optional import-following logic"
+readme = "README.md"
+license = "MIT"
+authors = [ { name = "Jim Schilling" } ]
+requires-python = ">=3.10"
+keywords = ["tests", "rename", "sentinel", "naming"]
+
+[project.urls]
+homepage = "https://github.com/jim-schilling/splurge-test-namer"
+
+[project.optional-dependencies]
+dev = [
+	"pytest>=7.0",
+	"pytest-cov",
+    "pytest-mock",
+    "pre-commit",
+	"ruff",
+]
+
+[build-system]
+requires = ["setuptools>=61.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[tool.ruff]
+line-length = 120
+
+[tool.mypy]
+python_version = "3.10"
+ignore_missing_imports = true
+exclude = "^tests/"
+

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+addopts = --cov=splurge_test_namer --cov-report=term-missing
+python_files = tests/**/*.py tests/*.py

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,9 @@
+# Pinned development dependencies for reproducible CI
+pytest==8.2.2
+pytest-cov==4.0.0
+pytest-mock==3.11.0
+pre-commit==3.3.3
+ruff==0.13.0
+black==23.9.1
+isort==5.12.0
+mypy==1.10.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,6 +4,4 @@ pytest-cov==4.0.0
 pytest-mock==3.11.0
 pre-commit==3.3.3
 ruff==0.13.0
-black==23.9.1
-isort==5.12.0
 mypy==1.10.0

--- a/splurge_test_namer/__init__.py
+++ b/splurge_test_namer/__init__.py
@@ -1,0 +1,5 @@
+"""
+__init__.py
+"""
+
+__domains__ = ["cli", "e2e", "integration", "misc", "namer", "parser", "regression", "utils"]

--- a/splurge_test_namer/cli.py
+++ b/splurge_test_namer/cli.py
@@ -1,0 +1,45 @@
+"""cli.py
+CLI entrypoint and argument parsing for test renamer tool."""
+
+from pathlib import Path
+import argparse
+
+from splurge_test_namer.namer import build_proposals, show_dry_run, apply_renames
+
+DOMAINS = ["cli"]
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse CLI arguments for the test renamer tool."""
+    p = argparse.ArgumentParser(description="Rename test modules based on <sentinel> metadata")
+    p.add_argument("--root", default="tests", help="Root tests directory to scan")
+    p.add_argument("--apply", action="store_true", help="Apply the renames (default is dry-run)")
+    p.add_argument("--sentinel", default="DOMAINS", help="Module-level sentinel list to read (default: DOMAINS)")
+    p.add_argument("--root-import", default=None, help="Root import path to follow from tests (optional)")
+    p.add_argument("--repo-root", default=None, help="Repository root path to resolve imports (optional)")
+    p.add_argument("-v", "--verbose", action="store_true", help="Enable verbose logging (debug)")
+    return p.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    root = Path(args.root)
+    sentinel = args.sentinel
+    root_import = args.root_import
+    repo_root = Path(args.repo_root) if args.repo_root else None
+    from splurge_test_namer.util_helpers import configure_logging
+
+    configure_logging(args.verbose)
+    if not root.exists():
+        print(f"Test root not found: {root}")
+        raise SystemExit(1)
+    proposals = build_proposals(root, sentinel, root_import=root_import, repo_root=repo_root)
+    if not args.apply:
+        show_dry_run(proposals)
+        print(f"\nProposals: {len(proposals)} (use --apply to perform)")
+        return
+    apply_renames(proposals)
+
+
+if __name__ == "__main__":
+    main()

--- a/splurge_test_namer/exceptions.py
+++ b/splurge_test_namer/exceptions.py
@@ -1,0 +1,38 @@
+"""exceptions.py
+Custom domain-specific exceptions for splurge_test_namer."""
+
+
+class SplurgeTestNamerError(Exception):
+    """Base exception for splurge_test_namer errors."""
+
+    pass
+
+
+class SentinelReadError(SplurgeTestNamerError):
+    """Raised when sentinel extraction from file fails."""
+
+    pass
+
+
+class FileRenameError(SplurgeTestNamerError):
+    """Raised when file renaming fails."""
+
+    pass
+
+
+class FileReadError(SplurgeTestNamerError):
+    """Raised when file reading fails."""
+
+    pass
+
+
+class FileWriteError(SplurgeTestNamerError):
+    """Raised when file writing fails."""
+
+    pass
+
+
+class FileGlobError(SplurgeTestNamerError):
+    """Raised when file globbing fails."""
+
+    pass

--- a/splurge_test_namer/namer.py
+++ b/splurge_test_namer/namer.py
@@ -1,0 +1,85 @@
+"""namer.py
+Naming logic and proposal building for test renamer tool."""
+
+from pathlib import Path
+from splurge_test_namer.parser import read_sentinels_from_file, aggregate_sentinels_for_test
+from splurge_test_namer.util_helpers import safe_file_rglob, safe_file_renamer
+from splurge_test_namer.exceptions import FileGlobError, FileRenameError, SplurgeTestNamerError
+import re
+from typing import List, Tuple, Optional
+
+DOMAINS = ["namer"]
+
+
+def slug_sentinel_list(sentinels: List[str]) -> str:
+    """Join sentinels with underscores and sanitize to [a-z0-9_]."""
+    joined = "_".join(d.strip().lower() for d in sentinels if d)
+    cleaned = re.sub(r"[^a-z0-9_]+", "_", joined)
+    cleaned = re.sub(r"_+", "_", cleaned).strip("_")
+    if not cleaned:
+        return "misc"
+    return cleaned
+
+
+def build_proposals(
+    root: Path,
+    sentinel: str,
+    root_import: Optional[str] = None,
+    repo_root: Optional[Path] = None,
+) -> List[Tuple[Path, Path]]:
+    """Scan test files and return a list of (original_path, proposed_path).
+
+    If root_import and repo_root are provided, aggregate sentinels from imported
+    modules under that root when building prefixes.
+    """
+    try:
+        files: List[Path] = sorted(safe_file_rglob(root, "*.py"))
+    except FileGlobError as e:
+        raise SplurgeTestNamerError(f"Failed to glob test files in {root}") from e
+    groups: dict[str, List[Path]] = {}
+    mapping: dict[Path, str] = {}
+    for f in files:
+        if any(part.lower() == "helpers" for part in f.parts):
+            continue
+        if not f.name.startswith("test_"):
+            continue
+        if root_import and repo_root:
+            domains = aggregate_sentinels_for_test(f, root_import, repo_root, sentinel)
+        else:
+            domains = read_sentinels_from_file(f, sentinel)
+        prefix = "test_" + slug_sentinel_list(domains)
+        mapping[f] = prefix
+        groups.setdefault(prefix, []).append(f)
+
+    proposals: List[Tuple[Path, Path]] = []
+    for prefix, flist in sorted(groups.items()):
+        flist_sorted = sorted(flist, key=lambda p: str(p).lower())
+        for idx, f in enumerate(flist_sorted, start=1):
+            seq = f"{idx:04d}"
+            new_name = f"{prefix}_{seq}.py"
+            new_path = f.with_name(new_name)
+            proposals.append((f, new_path))
+    return proposals
+
+
+def show_dry_run(proposals: List[Tuple[Path, Path]]) -> None:
+    print("DRY RUN - original | proposed")
+    for orig, prop in proposals:
+        print(f"{orig} | {prop.name}")
+
+
+def apply_renames(proposals: List[Tuple[Path, Path]]) -> None:
+    targets = {p for _, p in proposals}
+    for t in targets:
+        if t.exists() and t not in [o for o, _ in proposals]:
+            print(f"ERROR: target exists and is not being renamed: {t}")
+            raise SplurgeTestNamerError(f"Target exists and is not being renamed: {t}")
+
+    for orig, prop in proposals:
+        if orig == prop:
+            continue
+        print(f"[{orig}] -> [{prop}]")
+        try:
+            safe_file_renamer(orig, prop)
+        except FileRenameError as e:
+            raise SplurgeTestNamerError(f"Failed to rename {orig} to {prop}") from e

--- a/splurge_test_namer/parser.py
+++ b/splurge_test_namer/parser.py
@@ -1,0 +1,96 @@
+"""parser.py
+Sentinel extraction logic for test renamer tool."""
+
+import ast
+import re
+from pathlib import Path
+from splurge_test_namer.util_helpers import safe_file_reader, resolve_module_to_paths
+from splurge_test_namer.exceptions import FileReadError, SentinelReadError
+from typing import Set, List
+
+DOMAINS = ["parser"]
+
+
+def read_sentinels_from_file(path: Path, sentinel: str) -> List[str]:
+    """Return the module-level <sentinel> as a list of strings, or empty list. Raises SentinelReadError on file read error."""
+    try:
+        src = safe_file_reader(path)
+    except FileReadError as e:
+        raise SentinelReadError(f"Failed to extract sentinels from {path}") from e
+    try:
+        tree = ast.parse(src)
+    except Exception:
+        tree = None
+    if tree is not None:
+        for node in tree.body:
+            if isinstance(node, ast.Assign):
+                for t in node.targets:
+                    if isinstance(t, ast.Name) and t.id == sentinel:
+                        if isinstance(node.value, (ast.List, ast.Tuple)):
+                            out: list[str] = []
+                            for el in node.value.elts:
+                                if isinstance(el, ast.Constant) and isinstance(el.value, str):
+                                    out.append(el.value)
+                            return out
+                        return []
+    # fallback: regex
+    # allow leading whitespace before the sentinel so indented assignments (e.g. inside blocks)
+    m = re.search(rf"^\s*{sentinel}\s*=\s*\[(.*?)\]", src, re.S | re.M)
+    if m:
+        items = re.findall(r"['\"](.*?)['\"]", m.group(1))
+        return items
+    return []
+
+
+def find_imports_in_file(path: Path, root_import: str) -> Set[str]:
+    """Return dotted module names imported in `path` that start with `root_import`.
+
+    Handles `import X`, `import X as Y`, `from X import Y`, and `from X.Y import Z`.
+    """
+    try:
+        src = safe_file_reader(path)
+    except FileReadError:
+        return set()
+    if not src:
+        return set()
+    try:
+        tree = ast.parse(src)
+    except Exception:
+        return set()
+    found: Set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                name = alias.name
+                if name.startswith(root_import):
+                    found.add(name)
+        elif isinstance(node, ast.ImportFrom):
+            if node.module:
+                mod = node.module
+                # if level > 0, it's a relative import; skip
+                if node.level and node.level > 0:
+                    continue
+                if mod.startswith(root_import):
+                    found.add(mod)
+    return found
+
+
+def aggregate_sentinels_for_test(
+    test_path: Path, root_import: str, repo_root: Path, sentinel_name: str = "DOMAINS"
+) -> List[str]:
+    """Aggregate sentinel lists from modules imported by `test_path` under `root_import`.
+
+    Returns a sorted list of unique sentinel strings.
+    """
+    imports = find_imports_in_file(test_path, root_import)
+    sentinels: Set[str] = set()
+    for mod in sorted(imports):
+        paths = resolve_module_to_paths(mod, repo_root)
+        for p in paths:
+            try:
+                items = read_sentinels_from_file(p, sentinel_name)
+            except SentinelReadError:
+                items = []
+            for it in items:
+                sentinels.add(it)
+    return sorted(sentinels)

--- a/splurge_test_namer/util_helpers.py
+++ b/splurge_test_namer/util_helpers.py
@@ -1,0 +1,74 @@
+"""util_helpers.py
+Safe file operations for reading, writing, renaming, and rglob."""
+
+from pathlib import Path
+from splurge_test_namer.exceptions import FileReadError, FileWriteError, FileRenameError, FileGlobError
+from typing import List
+import logging
+
+LOGGER = logging.getLogger(__name__)
+
+
+def configure_logging(verbose: bool = False) -> None:
+    """Configure module logging level from CLI verbosity."""
+    level = logging.DEBUG if verbose else logging.INFO
+    logging.basicConfig(level=level, format="%(levelname)s: %(message)s")
+
+
+DOMAINS = ["utils"]
+
+
+def safe_file_reader(path: Path, encoding: str = "utf-8") -> str:
+    """Safely read file contents, raising FileReadError on error."""
+    try:
+        return path.read_text(encoding=encoding)
+    except Exception as e:
+        raise FileReadError(f"Failed to read file: {path}") from e
+
+
+def safe_file_writer(path: Path, data: str, encoding: str = "utf-8") -> None:
+    """Safely write data to file, raising FileWriteError on error."""
+    try:
+        path.write_text(data, encoding=encoding)
+    except Exception as e:
+        raise FileWriteError(f"Failed to write file: {path}") from e
+
+
+def safe_file_renamer(src: Path, dst: Path) -> None:
+    """Safely rename src to dst, raising FileRenameError on error."""
+    try:
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        src.replace(dst)
+    except Exception as e:
+        raise FileRenameError(f"Failed to rename {src} to {dst}") from e
+
+
+def safe_file_rglob(root: Path, pattern: str) -> List[Path]:
+    """Safely perform rglob, raising FileGlobError on error."""
+    try:
+        return list(root.rglob(pattern))
+    except Exception as e:
+        raise FileGlobError(f"Failed to rglob {pattern} in {root}") from e
+
+
+def resolve_module_to_paths(module_name: str, repo_root: Path) -> List[Path]:
+    """Resolve a dotted module name to candidate file paths inside repo_root.
+
+    Prefer module.py, then module/__init__.py. Returns empty list if nothing found.
+    """
+    parts = module_name.split(".")
+    candidates: List[Path] = []
+    # Try module as file: repo_root/parts[0]/.../parts[-1].py
+    file_path = repo_root.joinpath(*parts).with_suffix(".py")
+    if file_path.exists():
+        candidates.append(file_path)
+    # Try package __init__.py: repo_root/parts[0]/.../parts[-1]/__init__.py
+    pkg_init = repo_root.joinpath(*parts, "__init__.py")
+    if pkg_init.exists():
+        candidates.append(pkg_init)
+    # fallback: try to find any file under repo_root that ends with the module path
+    if not candidates:
+        for p in repo_root.rglob(parts[-1] + ".py"):
+            # ensure that the file path contains the module's parent directories (best-effort)
+            candidates.append(p)
+    return candidates

--- a/tests/integration/test_end_to_end_naming.py
+++ b/tests/integration/test_end_to_end_naming.py
@@ -1,0 +1,31 @@
+from splurge_test_namer.namer import build_proposals
+
+
+def test_end_to_end_naming(tmp_path):
+    # create a fake repo layout
+    repo = tmp_path / "repo"
+    tests = repo / "tests"
+    pkg = repo / "splurge_sql_tool"
+    (pkg).mkdir(parents=True)
+    (tests).mkdir(parents=True)
+
+    # create modules with DOMAINS
+    core = pkg / "core.py"
+    core.write_text("DOMAINS = ['core','sql']\n")
+    utils = pkg / "utils.py"
+    utils.write_text("DOMAINS = ['utils']\n")
+
+    # create test files importing those modules
+    t1 = tests / "test_a.py"
+    t1.write_text("from splurge_sql_tool.core import Query\n")
+    t2 = tests / "test_b.py"
+    t2.write_text("import splurge_sql_tool.utils as u\n")
+    t3 = tests / "test_c.py"
+    t3.write_text("# no imports\nDOMAINS = ['misc']\n")
+
+    proposals = build_proposals(tests, "DOMAINS", root_import="splurge_sql_tool", repo_root=repo)
+    # expect proposals to be created with prefixes using aggregated sentinels
+    names = [p.name for _, p in proposals]
+    assert any(n.startswith("test_core_sql_") for n in names)
+    assert any(n.startswith("test_utils_") for n in names)
+    assert any(n.startswith("test_misc_") for n in names)

--- a/tests/unit/test_aggregate_error_path.py
+++ b/tests/unit/test_aggregate_error_path.py
@@ -1,0 +1,32 @@
+
+from splurge_test_namer.parser import aggregate_sentinels_for_test
+from splurge_test_namer.util_helpers import resolve_module_to_paths
+
+
+def test_aggregate_handles_unreadable_module(tmp_path, monkeypatch):
+    repo = tmp_path / "repo"
+    tests = repo / "tests"
+    pkg = repo / "splurge_sql_tool"
+    pkg.mkdir(parents=True)
+    tests.mkdir(parents=True)
+
+    core = pkg / "core.py"
+    core.write_text("DOMAINS = ['core']\n")
+
+    t1 = tests / "test_badread.py"
+    t1.write_text("import splurge_sql_tool.core\n")
+
+    # make resolve_module_to_paths return the core path
+    paths = resolve_module_to_paths("splurge_sql_tool.core", repo)
+    assert any(p.samefile(core) for p in paths)
+
+    # monkeypatch the parser's safe_file_reader (it was imported there) to raise FileReadError
+    from splurge_test_namer.exceptions import FileReadError
+
+    monkeypatch.setattr(
+        "splurge_test_namer.parser.safe_file_reader", lambda p: (_ for _ in ()).throw(FileReadError("boom"))
+    )
+
+    sent = aggregate_sentinels_for_test(t1, "splurge_sql_tool", repo, "DOMAINS")
+    # should handle the read error and return empty
+    assert sent == []

--- a/tests/unit/test_aggregate_sentinels.py
+++ b/tests/unit/test_aggregate_sentinels.py
@@ -1,0 +1,35 @@
+from splurge_test_namer.parser import aggregate_sentinels_for_test
+
+
+def test_aggregate_sentinels_missing_module(tmp_path):
+    repo = tmp_path / "repo"
+    tests = repo / "tests"
+    pkg = repo / "splurge_sql_tool"
+    pkg.mkdir(parents=True)
+    tests.mkdir(parents=True)
+
+    # create a module that does not exist on disk (import only)
+    t1 = tests / "test_missing.py"
+    t1.write_text("from splurge_sql_tool.missing import something\n")
+
+    sent = aggregate_sentinels_for_test(t1, "splurge_sql_tool", repo, "DOMAINS")
+    assert sent == []
+
+
+def test_aggregate_sentinels_multiple_modules(tmp_path):
+    repo = tmp_path / "repo"
+    tests = repo / "tests"
+    pkg = repo / "splurge_sql_tool"
+    pkg.mkdir(parents=True)
+    tests.mkdir(parents=True)
+
+    core = pkg / "core.py"
+    core.write_text("DOMAINS = ['core']\n")
+    utils = pkg / "utils.py"
+    utils.write_text("DOMAINS = ['utils']\n")
+
+    t1 = tests / "test_multi.py"
+    t1.write_text("from splurge_sql_tool.core import Query\nimport splurge_sql_tool.utils\n")
+
+    sent = aggregate_sentinels_for_test(t1, "splurge_sql_tool", repo, "DOMAINS")
+    assert sent == ["core", "utils"]

--- a/tests/unit/test_apply_renames.py
+++ b/tests/unit/test_apply_renames.py
@@ -1,0 +1,29 @@
+import pytest
+
+from splurge_test_namer.namer import apply_renames
+from splurge_test_namer.exceptions import SplurgeTestNamerError
+
+
+def test_apply_renames_target_collision(tmp_path):
+    a = tmp_path / "tests" / "test_a.py"
+    b = tmp_path / "tests" / "test_b.py"
+    a.parent.mkdir(parents=True)
+    a.write_text("x")
+    b.write_text("y")
+
+    # propose renaming a -> existing file b (collision where b exists and is not in originals)
+    proposals = [(a, b)]
+    # Since b exists and is not an original in proposals, should raise
+    with pytest.raises(SplurgeTestNamerError):
+        apply_renames(proposals)
+
+
+def test_apply_renames_success(tmp_path):
+    a = tmp_path / "tests" / "test_a.py"
+    a.parent.mkdir(parents=True)
+    a.write_text("x")
+    target = a.with_name("test_misc_0001.py")
+    proposals = [(a, target)]
+    apply_renames(proposals)
+    assert target.exists()
+    assert not a.exists()

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,0 +1,51 @@
+import sys
+
+
+def run_cli_with_args(args, capsys, monkeypatch, proposals):
+    """Helper: patch build_proposals and apply_renames and run cli.main"""
+    from splurge_test_namer import cli
+
+    def fake_build(root, sentinel, root_import=None, repo_root=None):
+        return proposals
+
+    applied = {}
+
+    def fake_apply(ps):
+        applied["called"] = True
+        applied["ps"] = ps
+
+    # monkeypatch functions on the cli module so the imported references are overridden
+    monkeypatch.setattr(cli, "build_proposals", fake_build)
+    monkeypatch.setattr(cli, "apply_renames", fake_apply)
+
+    monkeypatch.setattr(sys, "argv", ["prog"] + args)
+    # run
+    cli.main()
+    captured = capsys.readouterr()
+    return captured, applied
+
+
+def test_cli_dry_run(tmp_path, capsys, monkeypatch):
+    # create fake proposals
+    orig = tmp_path / "tests" / "test_old.py"
+    orig.parent.mkdir(parents=True)
+    orig.write_text("# test")
+    prop = orig.with_name("test_misc_0001.py")
+    proposals = [(orig, prop)]
+
+    captured, applied = run_cli_with_args(["--root", str(tmp_path / "tests")], capsys, monkeypatch, proposals)
+    assert "DRY RUN - original | proposed" in captured.out
+    assert applied == {}
+
+
+def test_cli_apply_calls_apply_renames(tmp_path, capsys, monkeypatch):
+    orig = tmp_path / "tests" / "test_old.py"
+    orig.parent.mkdir(parents=True)
+    orig.write_text("# test")
+    prop = orig.with_name("test_misc_0001.py")
+    proposals = [(orig, prop)]
+
+    captured, applied = run_cli_with_args(
+        ["--root", str(tmp_path / "tests"), "--apply"], capsys, monkeypatch, proposals
+    )
+    assert applied.get("called") is True

--- a/tests/unit/test_focused_remaining.py
+++ b/tests/unit/test_focused_remaining.py
@@ -1,0 +1,34 @@
+import pytest
+
+from splurge_test_namer.namer import build_proposals
+from splurge_test_namer.exceptions import SplurgeTestNamerError
+
+
+def test_build_proposals_rglob_error(tmp_path, monkeypatch):
+    root = tmp_path / "tests"
+    root.mkdir()
+
+    # monkeypatch safe_file_rglob to raise
+    # monkeypatch the symbol used by namer (it imports safe_file_rglob into its module)
+    import splurge_test_namer.namer as nm
+
+    from splurge_test_namer.exceptions import FileGlobError
+
+    monkeypatch.setattr(nm, "safe_file_rglob", lambda root, pattern: (_ for _ in ()).throw(FileGlobError("boom")))
+
+    with pytest.raises(SplurgeTestNamerError):
+        build_proposals(root, "DOMAINS")
+
+
+def test_read_sentinels_inside_if_block(tmp_path):
+    p = tmp_path / "tests" / "test_if.py"
+    p.parent.mkdir(parents=True)
+    # sentinel defined inside an if block - top-level AST loop won't see it; regex fallback should match
+    p.write_text("""
+if True:
+    DOMAINS = ['inside']
+""")
+    from splurge_test_namer.parser import read_sentinels_from_file
+
+    vals = read_sentinels_from_file(p, "DOMAINS")
+    assert vals == ["inside"]

--- a/tests/unit/test_namer_and_parser_edges2.py
+++ b/tests/unit/test_namer_and_parser_edges2.py
@@ -1,0 +1,32 @@
+
+from splurge_test_namer.parser import find_imports_in_file, read_sentinels_from_file
+from splurge_test_namer.namer import build_proposals
+
+
+def test_helpers_directory_is_skipped(tmp_path):
+    root = tmp_path / "root"
+    helpers = root / "helpers"
+    helpers.mkdir(parents=True)
+    t = helpers / "test_helper_file.py"
+    t.write_text("DOMAINS = ['helper']\n")
+
+    proposals = build_proposals(root, "DOMAINS")
+    # helpers files should be skipped; no proposals
+    assert proposals == []
+
+
+def test_find_imports_empty_file(tmp_path):
+    p = tmp_path / "tests" / "test_empty.py"
+    p.parent.mkdir(parents=True)
+    p.write_text("")
+    found = find_imports_in_file(p, "splurge_sql_tool")
+    assert found == set()
+
+
+def test_read_sentinels_tuple_assignment(tmp_path):
+    p = tmp_path / "tests" / "test_tuple.py"
+    p.parent.mkdir(parents=True)
+    # sentinel assigned to a tuple should return list of strings
+    p.write_text("DOMAINS = ('one', 'two')\n")
+    vals = read_sentinels_from_file(p, "DOMAINS")
+    assert sorted(vals) == ["one", "two"]

--- a/tests/unit/test_namer_slug_and_build.py
+++ b/tests/unit/test_namer_slug_and_build.py
@@ -1,0 +1,33 @@
+
+from splurge_test_namer.namer import slug_sentinel_list, build_proposals
+
+
+def test_slug_sentinel_list_various():
+    assert slug_sentinel_list(["Core", "SQL-Utils"]) == "core_sql_utils"
+    assert slug_sentinel_list(["__weird__", "--name--"]) == "weird_name"
+    assert slug_sentinel_list([]) == "misc"
+
+
+def test_build_proposals_groups_and_sequencing(tmp_path):
+    tests_dir = tmp_path / "tests"
+    tests_dir.mkdir()
+
+    a = tests_dir / "test_a.py"
+    b = tests_dir / "test_b.py"
+    c = tests_dir / "test_c.py"
+    # two files with same domain, one with another
+    a.write_text("DOMAINS = ['alpha']\n")
+    b.write_text("DOMAINS = ['alpha']\n")
+    c.write_text("DOMAINS = ['beta']\n")
+
+    proposals = build_proposals(tests_dir, "DOMAINS")
+    # should produce three proposals
+    assert len(proposals) == 3
+    # group prefixes
+    names = [p.name for _, p in proposals]
+    assert any(n.startswith("test_alpha_") for n in names)
+    assert any(n.startswith("test_beta_") for n in names)
+    # alpha group should have two sequential numbers 0001 and 0002
+    alpha_names = sorted([n for n in names if n.startswith("test_alpha_")])
+    assert alpha_names[0].endswith("0001.py")
+    assert alpha_names[1].endswith("0002.py")

--- a/tests/unit/test_parser_and_resolver_extra.py
+++ b/tests/unit/test_parser_and_resolver_extra.py
@@ -1,0 +1,32 @@
+import textwrap
+
+from splurge_test_namer.parser import read_sentinels_from_file
+from splurge_test_namer.util_helpers import resolve_module_to_paths
+
+
+def test_read_sentinels_regex_fallback(tmp_path):
+    p = tmp_path / "tests" / "test_regex.py"
+    p.parent.mkdir(parents=True)
+    # write a file where AST parsing might not pick up (odd formatting)
+    p.write_text(
+        textwrap.dedent("""
+    DOMAINS = [
+        'one',
+        "two",
+    ]
+    """)
+    )
+    vals = read_sentinels_from_file(p, "DOMAINS")
+    assert sorted(vals) == ["one", "two"]
+
+
+def test_resolve_module_fallback_search(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    # create file deep in repo that ends with name 'utils.py'
+    deep = repo / "some" / "path" / "utils.py"
+    deep.parent.mkdir(parents=True)
+    deep.write_text("# utils")
+
+    found = resolve_module_to_paths("splurge_sql_tool.utils", repo)
+    assert any(p.samefile(deep) for p in found)

--- a/tests/unit/test_parser_edgecases.py
+++ b/tests/unit/test_parser_edgecases.py
@@ -1,0 +1,18 @@
+
+from splurge_test_namer.parser import find_imports_in_file
+
+
+def test_relative_import_ignored(tmp_path):
+    p = tmp_path / "tests" / "test_rel.py"
+    p.parent.mkdir(parents=True)
+    p.write_text("from . import core\n")
+    found = find_imports_in_file(p, "splurge_sql_tool")
+    assert found == set()
+
+
+def test_invalid_syntax_returns_empty(tmp_path):
+    p = tmp_path / "tests" / "test_bad.py"
+    p.parent.mkdir(parents=True)
+    p.write_text("def foo(:\n")
+    found = find_imports_in_file(p, "splurge_sql_tool")
+    assert found == set()

--- a/tests/unit/test_parser_imports.py
+++ b/tests/unit/test_parser_imports.py
@@ -1,0 +1,38 @@
+from pathlib import Path
+from splurge_test_namer.parser import find_imports_in_file
+
+
+def write_tmp(path: Path, content: str):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def test_find_imports_simple(tmp_path):
+    p = tmp_path / "tests" / "test_simple.py"
+    write_tmp(
+        p,
+        """
+import splurge_sql_tool.core
+from splurge_sql_tool.utils import helper
+import os
+""",
+    )
+    found = find_imports_in_file(p, "splurge_sql_tool")
+    assert "splurge_sql_tool.core" in found
+    assert "splurge_sql_tool.utils" in found
+    assert all(s.startswith("splurge_sql_tool") for s in found)
+
+
+def test_find_imports_alias_and_from(tmp_path):
+    p = tmp_path / "tests" / "test_alias.py"
+    write_tmp(
+        p,
+        """
+import splurge_sql_tool as s
+from splurge_sql_tool.subpkg import module as m
+from otherlib import stuff
+""",
+    )
+    found = find_imports_in_file(p, "splurge_sql_tool")
+    assert "splurge_sql_tool" in found
+    assert "splurge_sql_tool.subpkg" in found

--- a/tests/unit/test_parser_micro_branches.py
+++ b/tests/unit/test_parser_micro_branches.py
@@ -1,0 +1,36 @@
+import pytest
+
+from splurge_test_namer.parser import read_sentinels_from_file, find_imports_in_file
+from splurge_test_namer.exceptions import FileReadError, SentinelReadError
+
+
+def test_read_sentinels_parse_error_uses_regex(tmp_path):
+    p = tmp_path / "tests" / "test_parse_err.py"
+    p.parent.mkdir(parents=True)
+    # introduce a syntax error before the sentinel so ast.parse will fail
+    p.write_text("def bad(:\nDOMAINS = ['after_parse_error']\n")
+    vals = read_sentinels_from_file(p, "DOMAINS")
+    assert vals == ["after_parse_error"]
+
+
+def test_read_sentinels_raises_on_read_error(tmp_path, monkeypatch):
+    p = tmp_path / "tests" / "test_read_err.py"
+    p.parent.mkdir(parents=True)
+    p.write_text("DOMAINS = ['x']\n")
+    # monkeypatch the parser's safe_file_reader to raise FileReadError
+    import splurge_test_namer.parser as parser_mod
+
+    monkeypatch.setattr(parser_mod, "safe_file_reader", lambda path: (_ for _ in ()).throw(FileReadError("boom")))
+    with pytest.raises(SentinelReadError):
+        read_sentinels_from_file(p, "DOMAINS")
+
+
+def test_find_imports_returns_empty_on_read_error(tmp_path, monkeypatch):
+    p = tmp_path / "tests" / "test_read_err2.py"
+    p.parent.mkdir(parents=True)
+    p.write_text("import splurge_sql_tool.core\n")
+    import splurge_test_namer.parser as parser_mod
+
+    monkeypatch.setattr(parser_mod, "safe_file_reader", lambda path: (_ for _ in ()).throw(FileReadError("boom")))
+    found = find_imports_in_file(p, "splurge_sql_tool")
+    assert found == set()

--- a/tests/unit/test_parser_more_branches.py
+++ b/tests/unit/test_parser_more_branches.py
@@ -1,0 +1,44 @@
+import textwrap
+
+from splurge_test_namer.parser import find_imports_in_file, read_sentinels_from_file
+
+
+def test_find_imports_from_multiple_names(tmp_path):
+    p = tmp_path / "tests" / "test_multi_from.py"
+    p.parent.mkdir(parents=True)
+    p.write_text(
+        textwrap.dedent("""
+    from splurge_sql_tool.subpkg import a, b, c
+    from splurge_sql_tool.deep.module import X
+    """)
+    )
+    found = find_imports_in_file(p, "splurge_sql_tool")
+    assert "splurge_sql_tool.subpkg" in found
+    assert "splurge_sql_tool.deep.module" in found
+
+
+def test_read_sentinels_ast_non_list_assign(tmp_path):
+    p = tmp_path / "tests" / "test_nonlist.py"
+    p.parent.mkdir(parents=True)
+    # sentinel assigned to a string (not a list) should return [] per impl
+    p.write_text("DOMAINS = 'single'\n")
+    vals = read_sentinels_from_file(p, "DOMAINS")
+    assert vals == []
+
+
+def test_resolve_prefers_module_over_init(tmp_path):
+    repo = tmp_path / "repo"
+    pkg = repo / "splurge_sql_tool"
+    pkg.mkdir(parents=True)
+    mod = pkg / "utils.py"
+    init = pkg / "utils" / "__init__.py"
+    init.parent.mkdir(parents=True)
+    mod.write_text("# module")
+    init.write_text("# package init")
+
+    from splurge_test_namer.util_helpers import resolve_module_to_paths
+
+    paths = resolve_module_to_paths("splurge_sql_tool.utils", repo)
+    # should include module file and package init; module file preferred first
+    assert any(p.samefile(mod) for p in paths)
+    assert any(p.samefile(init) for p in paths)

--- a/tests/unit/test_util_helpers_errors.py
+++ b/tests/unit/test_util_helpers_errors.py
@@ -1,0 +1,32 @@
+import pytest
+from pathlib import Path
+
+from splurge_test_namer.util_helpers import safe_file_reader, safe_file_writer, safe_file_renamer
+from splurge_test_namer.exceptions import FileReadError, FileWriteError, FileRenameError
+
+
+def test_safe_file_reader_failure(tmp_path, monkeypatch):
+    p = tmp_path / "nope.py"
+    # monkeypatch Path.read_text to raise
+    monkeypatch.setattr(Path, "read_text", lambda self, encoding="utf-8": (_ for _ in ()).throw(Exception("fail")))
+    with pytest.raises(FileReadError):
+        safe_file_reader(p)
+
+
+def test_safe_file_writer_failure(tmp_path, monkeypatch):
+    p = tmp_path / "out.txt"
+    monkeypatch.setattr(
+        Path, "write_text", lambda self, data, encoding="utf-8": (_ for _ in ()).throw(Exception("fail"))
+    )
+    with pytest.raises(FileWriteError):
+        safe_file_writer(p, "data")
+
+
+def test_safe_file_renamer_failure(tmp_path, monkeypatch):
+    src = tmp_path / "a.txt"
+    dst = tmp_path / "b.txt"
+    src.write_text("x")
+    # monkeypatch Path.replace to raise
+    monkeypatch.setattr(Path, "replace", lambda self, other: (_ for _ in ()).throw(Exception("fail")))
+    with pytest.raises(FileRenameError):
+        safe_file_renamer(src, dst)

--- a/tests/unit/test_util_resolver.py
+++ b/tests/unit/test_util_resolver.py
@@ -1,0 +1,18 @@
+from splurge_test_namer.util_helpers import resolve_module_to_paths
+
+
+def test_resolve_module_file_and_package(tmp_path):
+    repo = tmp_path / "repo"
+    core_file = repo / "splurge_sql_tool" / "core.py"
+    pkg_init = repo / "splurge_sql_tool" / "utils" / "__init__.py"
+    pkg_init.parent.mkdir(parents=True, exist_ok=True)
+    core_file.parent.mkdir(parents=True, exist_ok=True)
+    core_file.write_text("# core module")
+    pkg_init.write_text("# utils package")
+
+    paths = resolve_module_to_paths("splurge_sql_tool.core", repo)
+    assert any(p.samefile(core_file) for p in paths)
+
+    paths2 = resolve_module_to_paths("splurge_sql_tool.utils", repo)
+    # should find __init__.py for utils
+    assert any(p.samefile(pkg_init) for p in paths2)

--- a/tools/rename_tests_by_sentinels.py
+++ b/tools/rename_tests_by_sentinels.py
@@ -1,0 +1,152 @@
+"""Rename test modules based on their <sentinel> metadata.
+
+Usage:
+  python tools/rename_tests_by_sentinels.py [--root tests] [--apply] [--sentinel DOMAINS]
+
+Default is a dry-run which prints "original | proposed". When --apply is used
+the script will perform os.rename and print "[original] -> [new]" for each
+rename.
+
+Naming rule:
+  test_<sentinel1>_<sentinel2>_<NNN>.py
+where sentinels come from the module-level <sentinel> list (order preserved) and
+NNN is a zero-padded 4-digit sequence per prefix.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import os
+import re
+from pathlib import Path
+
+
+def read_sentinels_from_file(path: Path, sentinel: str) -> list[str]:
+    """Return the module-level <sentinel> as a list of strings, or empty list."""
+    try:
+        src = path.read_text(encoding="utf-8")
+    except Exception:
+        return []
+    try:
+        tree = ast.parse(src)
+    except Exception:
+        tree = None
+    if tree is not None:
+        for node in tree.body:
+            if isinstance(node, ast.Assign):
+                for t in node.targets:
+                    if isinstance(t, ast.Name) and t.id == sentinel:
+                        if isinstance(node.value, (ast.List, ast.Tuple)):
+                            out: list[str] = []
+                            for el in node.value.elts:
+                                if isinstance(el, ast.Constant) and isinstance(el.value, str):
+                                    out.append(el.value)
+                            return out
+                        return []
+    # fallback: regex
+    m = re.search(rf"^{sentinel}\s*=\s*\[(.*?)\]", src, re.S | re.M)
+    if m:
+        items = re.findall(r"['\"](.*?)['\"]", m.group(1))
+        return items
+    return []
+
+
+def slug_sentinel_list(sentinels: list[str]) -> str:
+    # join with underscore and sanitize to [a-z0-9_]
+    joined = "_".join(d.strip().lower() for d in sentinels if d)
+    # replace non-alnum with underscore
+    cleaned = re.sub(r"[^a-z0-9_]+", "_", joined)
+    # collapse multiple underscores
+    cleaned = re.sub(r"_+", "_", cleaned).strip("_")
+    if not cleaned:
+        return "misc"
+    return cleaned
+
+
+def build_proposals(root: Path, sentinel: str) -> list[tuple[Path, Path]]:
+    """Scan test files and return a list of (original_path, proposed_path).
+
+    Proposed filenames are placed in the same directory as original files.
+    Sequence numbers are assigned per prefix across the whole scan.
+    """
+    files: list[Path] = sorted(root.rglob("*.py"))
+    # gather list of (file, prefix)
+    groups: dict[str, list[Path]] = {}
+    mapping: dict[Path, str] = {}
+    for f in files:
+        # Skip files in helper directories (they are package modules used by tests)
+        # and skip non-test files (we only want to rename files that already
+        # follow the `test_` prefix). This prevents renaming helpers and
+        # special files like conftest.py.
+        if any(part.lower() == "helpers" for part in f.parts):
+            continue
+        if not f.name.startswith("test_"):
+            # skip conftest.py and other non-test modules
+            continue
+        domains = read_sentinels_from_file(f, sentinel)
+        prefix = "test_" + slug_sentinel_list(domains)
+        mapping[f] = prefix
+        groups.setdefault(prefix, []).append(f)
+
+    proposals: list[tuple[Path, Path]] = []
+    # for each prefix, sort files to make deterministic sequence
+    for prefix, flist in sorted(groups.items()):
+        flist_sorted = sorted(flist, key=lambda p: str(p).lower())
+        for idx, f in enumerate(flist_sorted, start=1):
+            seq = f"{idx:04d}"
+            new_name = f"{prefix}_{seq}.py"
+            new_path = f.with_name(new_name)
+            proposals.append((f, new_path))
+    return proposals
+
+
+def show_dry_run(proposals: list[tuple[Path, Path]]) -> None:
+    print("DRY RUN - original | proposed")
+    for orig, prop in proposals:
+        print(f"{orig} | {prop.name}")
+
+
+def apply_renames(proposals: list[tuple[Path, Path]]) -> None:
+    # first ensure no target collisions outside of the rename set
+    targets = {p for _, p in proposals}
+    for t in targets:
+        if t.exists() and t not in [o for o, _ in proposals]:
+            print(f"ERROR: target exists and is not being renamed: {t}")
+            raise SystemExit(1)
+
+    for orig, prop in proposals:
+        if orig == prop:
+            continue
+        # if prop exists and is one of the originals, it's fine; perform rename
+        print(f"[{orig}] -> [{prop}]")
+        prop.parent.mkdir(parents=True, exist_ok=True)
+        os.replace(str(orig), str(prop))
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="Rename test modules based on <sentinel> metadata")
+    p.add_argument("--root", default="tests", help="Root tests directory to scan")
+    p.add_argument("--apply", action="store_true", help="Apply the renames (default is dry-run)")
+    p.add_argument("--sentinel", default="DOMAINS", help="Module-level sentinel list to read (default: DOMAINS)")
+    return p.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    root = Path(args.root)
+    sentinel = args.sentinel
+    if not root.exists():
+        print(f"Test root not found: {root}")
+        raise SystemExit(1)
+    proposals = build_proposals(root, sentinel)
+    if not args.apply:
+        show_dry_run(proposals)
+        print(f"\nProposals: {len(proposals)} (use --apply to perform)")
+        return
+    # apply
+    apply_renames(proposals)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This pull request introduces a comprehensive set of standards and guidelines for the project, focusing on code quality, design, documentation, naming, testing, security, style, CLI, Python, and project organization. These standards are defined in dedicated markdown files under the `.cursor/rules/` directory, providing clear expectations for contributors and ensuring consistency across the codebase.

**Project-wide standards and organization:**

* Added `.cursor/rules/project-standards.mdc` to define project folder structure, documentation requirements, versioning, licensing, and author/maintainer information.

**Code quality, design, and style standards:**

* Added `.cursor/rules/design-standards.mdc` to enforce SOLID, DRY, MVP, KISS, PoLA, YAGNI, and other design principles.
* Added `.cursor/rules/style-standards.mdc` to specify formatting, line length, blank lines, and avoidance of magic values.
* Added `.cursor/rules/naming-standards.mdc` to clarify naming conventions for variables, classes, constants, environment variables, and test modules.

**Language and CLI standards:**

* Added `.cursor/rules/python-standards.mdc` to require type annotations, PEP 8 adherence, modern Python practices, and domain tagging.
* Added `.cursor/rules/cli-standards.mdc` to define CLI input/output, environment variable usage, output formats, exit codes, and error handling.

**Testing, documentation, security, and SDLC standards:**

* Added `.cursor/rules/testing-standards.mdc` for test organization, coverage, pytest usage, and test naming.
* Added `.cursor/rules/documentation-standards.mdc` for commenting and docstring requirements, including Google-style docstrings for Python.
* Added `.cursor/rules/security-standards.mdc` for secure coding, input validation, authentication, error handling, and OWASP guidelines.
* Added `.cursor/rules/sdlc-standards.mdc` for research, planning, implementation lifecycle, documentation, and CLI requirements for tools and libraries.

Additionally, a coverage badge file was added to `.github/badges/coverage.json`.