### PR TITLE
ci: add pull-requests permission for coverage badge updates

### DIFF
--- a/.github/workflows/coverage-commit.yml
+++ b/.github/workflows/coverage-commit.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   coverage-commit:


### PR DESCRIPTION
This pull request makes a small update to the GitHub Actions workflow permissions. The change grants write access to pull requests in the `.github/workflows/coverage-commit.yml` file.