### PR TITLE
fix: standardize python-version array syntax in CI workflow

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.10, 3.11, 3.12, 3.13]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
This pull request makes a minor update to the Python CI workflow configuration, ensuring that all Python version values in the matrix are specified as strings rather than numbers. This change improves consistency and prevents potential issues with YAML parsing.