### PR TITLE
ci: update coverage badge JSON and workflow (generate badge and push/…

### DIFF
--- a/.github/badges/coverage.json
+++ b/.github/badges/coverage.json
@@ -1,1 +1,1 @@
-{"schemaVersion":1,"label":"coverage","message":"unknown","color":"lightgrey"}
+{"schemaVersion": 1, "label": "coverage", "message": "94.06%", "color": "brightgreen"}

--- a/.github/workflows/coverage-commit.yml
+++ b/.github/workflows/coverage-commit.yml
@@ -13,6 +13,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: true
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
@@ -52,7 +55,33 @@ jobs:
           fi
           mkdir -p .github/badges
           jq -n --arg label "coverage" --arg message "$msg" --arg color "$color" '{schemaVersion:1, label:$label, message:$message, color:$color}' > .github/badges/coverage.json
-      - name: Create PR with updated badge
+
+      - name: Commit and push badge to main (try)
+        id: try-push
+        run: |
+          set -euo pipefail
+          pct=${{ steps.coverage.outputs.coverage_percent }}
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add .github/badges/coverage.json || true
+          # if no changes staged, nothing to do
+          if git diff --staged --quiet; then
+            echo "changed=false" >> $GITHUB_OUTPUT
+            echo "pushed=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          git commit -m "ci: update coverage badge to ${pct}% [skip ci]" || true
+          # Try to push directly to main. If push fails (branch protection), record pushed=false
+          if git push origin HEAD:main; then
+            echo "changed=true" >> $GITHUB_OUTPUT
+            echo "pushed=true" >> $GITHUB_OUTPUT
+          else
+            echo "changed=true" >> $GITHUB_OUTPUT
+            echo "pushed=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create PR with updated badge (fallback)
+        if: steps.try-push.outputs.pushed != 'true' && steps.try-push.outputs.changed == 'true'
         uses: peter-evans/create-pull-request@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION

This pull request improves the coverage badge update workflow by making the badge update process more robust and automating direct updates to `main` when possible. The workflow now tries to push coverage badge changes directly to `main`, and only creates a pull request if the direct push fails (e.g., due to branch protection). Additionally, it updates the badge to reflect the latest coverage percentage.

**Coverage badge update improvements:**

* Updated `.github/badges/coverage.json` to show the current coverage percentage (`94.06%`) and changed the badge color to `brightgreen` for better visibility.

**Workflow automation enhancements:**

* In `.github/workflows/coverage-commit.yml`, added `fetch-depth: 0` and `persist-credentials: true` to the checkout step to ensure full history and proper authentication for badge updates.
* Added a new step to attempt committing and pushing the updated coverage badge directly to `main`, with logic to handle cases where no changes are present or push fails due to branch protection.
* Modified the workflow to only create a pull request for the badge update if the direct push to `main` fails, making the process more efficient and reducing unnecessary PRs.