### PR TITLE
fix(ci): correct coverage output write to GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/coverage-commit.yml
+++ b/.github/workflows/coverage-commit.yml
@@ -31,27 +31,30 @@ jobs:
         id: coverage
         run: |
           python - <<'PY'
-          import sys
-          from pathlib import Path
-          import xml.etree.ElementTree as ET
+            import os
+            from pathlib import Path
+            import xml.etree.ElementTree as ET
 
-          covfile = Path('coverage.xml')
-          out = 'unknown'
-          if covfile.exists():
-              try:
-                  tree = ET.parse(covfile)
-                  root = tree.getroot()
-                  line_rate = root.attrib.get('line-rate')
-                  if line_rate is not None:
-                      pct = float(line_rate) * 100.0
-                      out = f"{pct:.2f}"
-              except Exception:
-                  out = 'unknown'
-          # write to GITHUB_OUTPUT
-          print(f"coverage_percent={out}")
-          with open(sys.argv[1], 'a') as fh:
-              fh.write(f"coverage_percent={out}\n")
-          PY $GITHUB_OUTPUT
+            covfile = Path('coverage.xml')
+            out = 'unknown'
+            if covfile.exists():
+                try:
+                    tree = ET.parse(covfile)
+                    root = tree.getroot()
+                    line_rate = root.attrib.get('line-rate')
+                    if line_rate is not None:
+                        pct = float(line_rate) * 100.0
+                        out = f"{pct:.2f}"
+                except Exception:
+                    out = 'unknown'
+            github_out = os.environ.get('GITHUB_OUTPUT')
+            if github_out:
+                with open(github_out, 'a') as fh:
+                    fh.write(f"coverage_percent={out}\n")
+            else:
+                # fallback for local debugging
+                print(f"coverage_percent={out}")
+          PY
       - name: Update badge JSON
         run: |
           pct=${{ steps.coverage.outputs.coverage_percent }}


### PR DESCRIPTION
Fix the Compute coverage percent step so Python writes to GITHUB_OUTPUT correctly.