### PR TITLE
Refactor CLI arguments and enhance import scanning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ __pycache__/
 # C extensions
 *.so
 
+tmp/
+tmp_scan/
+
 # Distribution / packaging
 .Python
 build/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # 2025.0.0 - 2025-09-15
 
 - Added import-following mode: aggregate sentinels from imported modules under a root package.
-- Added CLI flags: `--root-import`, `--repo-root`, `--verbose`.
+- Added CLI flags: `--import-root`, `--repo-root`, `--verbose`.
 - Improved API: parser.find_imports_in_file, parser.aggregate_sentinels_for_test, util_helpers.resolve_module_to_paths.
 - Added tests for import scanning, module resolution, and end-to-end naming.
 

--- a/README.md
+++ b/README.md
@@ -21,16 +21,16 @@ A small tool to rename test modules based on module-level sentinel lists (e.g. `
 
 Usage
 -----
-- Dry run: `python -m splurge_test_namer.cli --root tests`
-- Apply renames: `python -m splurge_test_namer.cli --root tests --apply`
-- Follow imports under a root package: `python -m splurge_test_namer.cli --root tests --root-import splurge_sql_tool --repo-root /path/to/repo`
+-- Dry run: `python -m splurge_test_namer.cli --test-root tests`
+-- Apply renames: `python -m splurge_test_namer.cli --test-root tests --apply`
+-- Follow imports under a root package: `python -m splurge_test_namer.cli --test-root tests --import-root splurge_sql_tool --repo-root /path/to/repo`
 
 Force/overwrite behavior
 ------------------------
 By default the tool will not overwrite existing files. To allow overwriting targets when applying proposals, pass `--force` together with `--apply`:
 
 ```bash
-python -m splurge_test_namer.cli --root tests --apply --force
+python -m splurge_test_namer.cli --test-root tests --apply --force
 ```
 +
 
@@ -93,6 +93,6 @@ pre-commit run --all-files
 New in 2025.0.0
 ---------------
 - Import-following mode: aggregate sentinels from imported modules under a root package when proposing test filenames.
-- CLI flags: `--root-import`, `--repo-root`, `--verbose`.
+-- CLI flags: `--import-root`, `--repo-root`, `--verbose`.
 +
 See `docs/README-DETAILS.md` for full API and design notes.

--- a/docs/README-DETAILS.md
+++ b/docs/README-DETAILS.md
@@ -32,10 +32,10 @@ Errors and Logging
 
 CLI
 ---
-- `--root`: tests root to scan (default: `tests`)
+-- `--test-root`: tests root to scan (default: `tests`)
 - `--apply`: apply renames (default: dry-run)
 - `--sentinel`: sentinel variable name (default: `DOMAINS`)
-- `--root-import`: root import package to follow (optional)
+-- `--import-root`: import-root package to follow (optional)
 - `--repo-root`: filesystem path to repository root for resolving imports (optional)
 - `-v/--verbose`: enable verbose debug logging
 
@@ -97,7 +97,7 @@ Force/overwrite behavior
 By default the renamer will not overwrite existing files when applying proposals. To allow overwrites (for example when you intentionally want to replace files), run with the `--force` flag together with `--apply`:
 
 ```bash
-python -m splurge_test_namer.cli --root tests --apply --force
+python -m splurge_test_namer.cli --test-root tests --apply --force
 ```
 +
 

--- a/docs/plans/plan-import-scan-2025-sep-15.md
+++ b/docs/plans/plan-import-scan-2025-sep-15.md
@@ -89,6 +89,6 @@ Notes and next steps
 2. Implement `util_helpers.resolve_module_to_paths`.
 3. Implement `parser.aggregate_sentinels_for_test` using the existing `read_sentinels_from_file`.
 4. Update `namer.build_proposals` to accept `root_import` and `repo_root` and use aggregated sentinels.
-5. Add `--root-import` CLI flag to `cli.py` and update help documentation.
+5. Add `--import-root` CLI flag to `cli.py` and update help documentation.
 
 If you want, I can start implementing step 2 (add import scanner in `parser.py`) and mark that todo `in-progress`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,10 @@ dev = [
 	"ruff",
 ]
 
+[project.scripts]
+# Console script entry: installs `splurge-test-namer` command that invokes the CLI
+splurge-test-namer = "splurge_test_namer.cli:main"
+
 [build-system]
 requires = ["setuptools>=61.0", "wheel"]
 build-backend = "setuptools.build_meta"
@@ -31,4 +35,7 @@ line-length = 120
 python_version = "3.10"
 ignore_missing_imports = true
 exclude = "^tests/"
+
+[tool.setuptools.packages.find]
+exclude = ["tmp_scan"]
 

--- a/splurge_test_namer/parser.py
+++ b/splurge_test_namer/parser.py
@@ -9,13 +9,44 @@ License: MIT
 """
 
 import ast
+import logging
 import re
 from pathlib import Path
-from splurge_test_namer.util_helpers import safe_file_reader, resolve_module_to_paths
-from splurge_test_namer.exceptions import FileReadError, SentinelReadError
 from typing import Set, Optional
 
+from splurge_test_namer.util_helpers import (
+    safe_file_reader,
+    resolve_module_to_paths_with_member_fallback,
+)
+from splurge_test_namer.exceptions import FileReadError, SentinelReadError
+
 DOMAINS = ["parser"]
+
+
+def _eval_constant_string_binop(node: ast.AST, const_map: Optional[dict[str, str]] = None) -> Optional[str]:
+    """Evaluate simple string concatenation BinOp nodes composed of Constant strings.
+
+    Returns the concatenated string or None if it cannot be resolved.
+    """
+    # only support left-heavy chains of BinOp with Add and Constant string nodes
+    if not isinstance(node, ast.BinOp):
+        return None
+    if not isinstance(node.op, ast.Add):
+        return None
+
+    def eval_node(n: ast.AST) -> Optional[str]:
+        if isinstance(n, ast.Constant) and isinstance(n.value, str):
+            return n.value
+        if isinstance(n, ast.Name) and const_map is not None:
+            return const_map.get(n.id)
+        if isinstance(n, ast.BinOp) and isinstance(n.op, ast.Add):
+            left = eval_node(n.left)
+            right = eval_node(n.right)
+            if left is not None and right is not None:
+                return left + right
+        return None
+
+    return eval_node(node)
 
 
 def read_sentinels_from_file(path: Path, sentinel: str) -> list[str]:
@@ -41,37 +72,42 @@ def read_sentinels_from_file(path: Path, sentinel: str) -> list[str]:
         src = safe_file_reader(path)
     except FileReadError as e:
         raise SentinelReadError(f"Failed to extract sentinels from {path}") from e
+
     try:
         tree = ast.parse(src)
     except Exception:
         tree = None
+
     if tree is not None:
         for node in tree.body:
             # Handle simple assignments: SENTINEL = ['a', 'b']
             if isinstance(node, ast.Assign):
                 for t in node.targets:
                     if isinstance(t, ast.Name) and t.id == sentinel:
-                        if isinstance(node.value, (ast.List, ast.Tuple)):
+                        val = node.value
+                        if isinstance(val, (ast.List, ast.Tuple)):
                             out: list[str] = []
-                            for el in node.value.elts:
+                            for el in val.elts:
                                 if isinstance(el, ast.Constant) and isinstance(el.value, str):
                                     out.append(el.value)
                             return out
                         return []
+
             # Handle annotated assignments (PEP 526): SENTINEL: list[str] = ['a']
             if isinstance(node, ast.AnnAssign):
                 target = node.target
                 if isinstance(target, ast.Name) and target.id == sentinel:
                     # value may be None if only annotation provided; we only
                     # accept cases with an explicit value that's a list/tuple
-                    val = node.value
-                    if isinstance(val, (ast.List, ast.Tuple)):
+                    ann_val = node.value
+                    if isinstance(ann_val, (ast.List, ast.Tuple)):
                         out_items: list[str] = []
-                        for el in val.elts:
+                        for el in ann_val.elts:
                             if isinstance(el, ast.Constant) and isinstance(el.value, str):
                                 out_items.append(el.value)
                         return out_items
                     return []
+
     # fallback: regex
     # allow leading whitespace before the sentinel so indented assignments (e.g. inside blocks)
     # Regex fallback: accept optional type annotation between the name and '='
@@ -89,7 +125,13 @@ def find_imports_in_file(path: Path, root_import: str, repo_root: Optional[Path]
     """Return dotted module names imported in `path` that start with `root_import`.
 
     Handles `import X`, `import X as Y`, `from X import Y`, and `from X.Y import Z`.
+    Also recognizes a limited set of dynamic imports where the module name is a
+    string literal: importlib.import_module('pkg.mod'), __import__('pkg.mod'),
+    or loader.load_module('pkg.mod') where the loader variable was created via
+    importlib.machinery.SourceFileLoader(...).
     """
+    logger = logging.getLogger(__name__)
+
     try:
         src = safe_file_reader(path)
     except FileReadError:
@@ -100,7 +142,63 @@ def find_imports_in_file(path: Path, root_import: str, repo_root: Optional[Path]
         tree = ast.parse(src)
     except Exception:
         return set()
+
     found: Set[str] = set()
+    # Map variable names that are assigned to importlib SourceFileLoader(...) so
+    # we can recognize subsequent loader.load_module(...) calls as dynamic imports.
+    loader_vars: set[str] = set()
+    # Map simple NAME = "literal" assignments so we can resolve names passed
+    # to dynamic import functions when the name is a constant string.
+    const_string_vars: dict[str, str] = {}
+    for node in tree.body:
+        if isinstance(node, ast.Assign):
+            # only simple assignments: NAME = Call(...)
+            if len(node.targets) != 1:
+                continue
+            target = node.targets[0]
+            if not isinstance(target, ast.Name):
+                continue
+            val = node.value
+            if isinstance(val, ast.Call) and isinstance(val.func, (ast.Attribute, ast.Name)):
+                # build dotted name of the constructor
+                def dotted_from(n: ast.AST) -> Optional[str]:
+                    dotted_parts: list[str] = []
+                    cur = n
+                    while True:
+                        if isinstance(cur, ast.Name):
+                            dotted_parts.append(cur.id)
+                            break
+                        if isinstance(cur, ast.Attribute):
+                            dotted_parts.append(cur.attr)
+                            cur = cur.value
+                            continue
+                        return None
+                    return ".".join(reversed(dotted_parts))
+
+                dotted = dotted_from(val.func)
+                if dotted and "SourceFileLoader" in dotted and dotted.split(".")[0] == "importlib":
+                    loader_vars.add(target.id)
+            # capture simple constant string assignments: NAME = 'pkg.mod'
+            elif isinstance(val, ast.Constant) and isinstance(val.value, str):
+                const_string_vars[target.id] = val.value
+            # capture simple concatenations of constants or names: NAME = 'a' + '.b' or A + B
+            elif isinstance(val, ast.BinOp):
+                resolved = _eval_constant_string_binop(val, const_string_vars)
+                if resolved is not None:
+                    const_string_vars[target.id] = resolved
+            # capture simple f-strings with only constant parts (JoinedStr)
+            elif isinstance(val, ast.JoinedStr):
+                joined_parts: list[str] = []
+                ok = True
+                for v in val.values:
+                    if isinstance(v, ast.Constant) and isinstance(v.value, str):
+                        joined_parts.append(v.value)
+                    else:
+                        ok = False
+                        break
+                if ok:
+                    const_string_vars[target.id] = "".join(joined_parts)
+
     # Determine base module name for relative import resolution if repo_root provided
     base_module: Optional[str] = None
     try:
@@ -109,77 +207,175 @@ def find_imports_in_file(path: Path, root_import: str, repo_root: Optional[Path]
             base_module = ".".join(rel.parts)
     except Exception:
         base_module = None
-    for node in ast.walk(tree):
-        if isinstance(node, ast.Import):
-            for alias in node.names:
+
+    for n in ast.walk(tree):
+        if isinstance(n, ast.Import):
+            for alias in n.names:
                 name = alias.name
                 if name.startswith(root_import):
+                    logger.debug("static import detected: %s", name)
                     found.add(name)
-        elif isinstance(node, ast.ImportFrom):
-            if node.module:
-                mod = node.module
-                # if level > 0, it's a relative import; skip
-                if node.level and node.level > 0:
-                    # Resolve relative import against the base module if available
-                    if base_module is None:
-                        continue
-                    base_parts = base_module.split(".")
-                    # climb up `level` parts
-                    if node.level > len(base_parts):
-                        continue
-                    parent = ".".join(base_parts[: -node.level])
-                    if node.module:
-                        # from ..mod import name -> parent.mod and parent.mod.name
-                        full_mod = f"{parent}.{node.module}" if parent else node.module
-                    else:
-                        # from .. import name -> parent
-                        full_mod = parent
-                    if full_mod and full_mod.startswith(root_import):
-                        found.add(full_mod)
-                    for alias in node.names:
-                        if alias.name == "*":
-                            # Expand star imports by listing submodules under the
-                            # package directory when repo_root is available.
-                            if repo_root is not None:
-                                try:
-                                    pkg_dir = repo_root.joinpath(*mod.split("."))
-                                    if pkg_dir.exists() and pkg_dir.is_dir():
-                                        for child in pkg_dir.iterdir():
-                                            if child.suffix == ".py" and child.name != "__init__.py":
-                                                candidate = f"{mod}.{child.stem}"
-                                                if candidate.startswith(root_import):
-                                                    found.add(candidate)
-                                except Exception:
-                                    pass
-                            # also keep the module itself so __init__ can be inspected
-                            found.add(mod)
-                            continue
-                        candidate = f"{full_mod}.{alias.name}" if full_mod else alias.name
-                        if candidate.startswith(root_import):
-                            found.add(candidate)
+
+        elif isinstance(n, ast.ImportFrom):
+            # n.module may be None for constructs like `from . import name`.
+            mod = n.module
+            # if level > 0, it's a relative import; attempt to resolve
+            if n.level and n.level > 0:
+                # Resolve relative import against the base module if available
+                if base_module is None:
+                    continue
+                base_parts = base_module.split(".")
+                # climb up `level` parts
+                if n.level > len(base_parts):
+                    continue
+                parent = ".".join(base_parts[: -n.level])
+                if mod:
+                    # from ..mod import name -> parent.mod and parent.mod.name
+                    full_mod = f"{parent}.{mod}" if parent else mod
                 else:
-                    # Add the explicit module (e.g. 'pkg.sub') if it matches
-                    if mod.startswith(root_import):
-                        found.add(mod)
-                    # Also handle 'from pkg import submodule' -> record 'pkg.submodule'
-                    for alias in node.names:
-                        if alias.name == "*":
-                            if repo_root is not None:
-                                try:
-                                    pkg_dir = repo_root.joinpath(*mod.split("."))
-                                    if pkg_dir.exists() and pkg_dir.is_dir():
-                                        for child in pkg_dir.iterdir():
-                                            if child.suffix == ".py" and child.name != "__init__.py":
-                                                candidate = f"{mod}.{child.stem}"
-                                                if candidate.startswith(root_import):
-                                                    found.add(candidate)
-                                except Exception:
-                                    pass
+                    # from .. import name -> parent
+                    full_mod = parent
+                if full_mod and full_mod.startswith(root_import):
+                    logger.debug("from-import (relative resolved) detected: %s", full_mod)
+                    found.add(full_mod)
+                for alias in n.names:
+                    if alias.name == "*":
+                        # Expand star imports by listing submodules under the
+                        # package directory when repo_root is available.
+                        if repo_root is not None and mod:
+                            try:
+                                pkg_dir = repo_root.joinpath(*mod.split("."))
+                                if pkg_dir.exists() and pkg_dir.is_dir():
+                                    for child in pkg_dir.iterdir():
+                                        if child.suffix == ".py" and child.name != "__init__.py":
+                                            candidate = f"{mod}.{child.stem}"
+                                            if candidate.startswith(root_import):
+                                                logger.debug("star-import expansion candidate: %s", candidate)
+                                                found.add(candidate)
+                            except Exception:
+                                pass
+                        # also keep the module or parent so __init__ can be inspected
+                        logger.debug("from-import star keep module: %s", mod or full_mod)
+                        if mod:
                             found.add(mod)
-                            continue
-                        candidate = f"{mod}.{alias.name}"
-                        if candidate.startswith(root_import):
-                            found.add(candidate)
+                        elif full_mod:
+                            found.add(full_mod)
+                        continue
+                    candidate = f"{full_mod}.{alias.name}" if full_mod else alias.name
+                    if candidate.startswith(root_import):
+                        logger.debug("from-import alias detected: %s", candidate)
+                        found.add(candidate)
+            else:
+                # Non-relative from-import
+                if mod and mod.startswith(root_import):
+                    logger.debug("from-import module detected: %s", mod)
+                    found.add(mod)
+                # Also handle 'from pkg import submodule' -> record 'pkg.submodule'
+                for alias in n.names:
+                    if alias.name == "*":
+                        if repo_root is not None and mod:
+                            try:
+                                pkg_dir = repo_root.joinpath(*mod.split("."))
+                                if pkg_dir.exists() and pkg_dir.is_dir():
+                                    for child in pkg_dir.iterdir():
+                                        if child.suffix == ".py" and child.name != "__init__.py":
+                                            candidate = f"{mod}.{child.stem}"
+                                            if candidate.startswith(root_import):
+                                                logger.debug("star-import expansion candidate: %s", candidate)
+                                                found.add(candidate)
+                            except Exception:
+                                pass
+                        logger.debug("from-import star keep module: %s", mod)
+                        if mod:
+                            found.add(mod)
+                        continue
+                    if not mod:
+                        # from X import name where X is None is unusual for
+                        # non-relative imports; skip defensively
+                        continue
+                    candidate = f"{mod}.{alias.name}"
+                    if candidate.startswith(root_import):
+                        logger.debug("from-import candidate detected: %s", candidate)
+                        found.add(candidate)
+
+        # detect dynamic import calls like importlib.import_module("pkg.mod")
+        elif isinstance(n, ast.Call):
+            func = n.func
+            is_import_call = False
+
+            def dotted_name_from_attr(attr_node: ast.AST) -> Optional[str]:
+                """Return dotted name for nested ast.Attribute/ast.Name or None."""
+                attr_parts: list[str] = []
+                cur = attr_node
+                while True:
+                    if isinstance(cur, ast.Name):
+                        attr_parts.append(cur.id)
+                        break
+                    if isinstance(cur, ast.Attribute):
+                        attr_parts.append(cur.attr)
+                        cur = cur.value
+                        continue
+                    return None
+                return ".".join(reversed(attr_parts))
+
+            # handle attribute-style calls (importlib.import_module, importlib.machinery.SourceFileLoader.load_module)
+            if isinstance(func, ast.Attribute):
+                dotted = dotted_name_from_attr(func)
+                # dotted will be like 'importlib.import_module' or 'importlib.machinery.SourceFileLoader.load_module'
+                if dotted:
+                    if dotted.endswith("import_module"):
+                        # require 'importlib' to appear in the dotted path
+                        if dotted.split(".")[0] == "importlib":
+                            is_import_call = True
+                    elif dotted.endswith("load_module"):
+                        lead = dotted.split(".")[0]
+                        # either importlib.machinery.SourceFileLoader.load_module
+                        # or a variable name assigned earlier to a SourceFileLoader
+                        if lead == "importlib" or lead in loader_vars:
+                            is_import_call = True
+                else:
+                    # handle loader.load_module('...') where loader was created earlier
+                    if isinstance(func.value, ast.Name) and func.attr == "load_module":
+                        if func.value.id in loader_vars:
+                            is_import_call = True
+            # name-style calls: __import__, import_module
+            elif isinstance(func, ast.Name):
+                if func.id in ("__import__", "import_module"):
+                    is_import_call = True
+
+            if is_import_call and n.args:
+                first = n.args[0]
+                modname: Optional[str] = None
+                # literal string
+                if isinstance(first, ast.Constant) and isinstance(first.value, str):
+                    modname = first.value
+                # simple name referencing a literal assigned above
+                elif isinstance(first, ast.Name) and first.id in const_string_vars:
+                    modname = const_string_vars[first.id]
+                # simple concatenation of constants
+                elif isinstance(first, ast.BinOp):
+                    modname = _eval_constant_string_binop(first)
+                # f-strings (JoinedStr) with only constant parts
+                elif isinstance(first, ast.JoinedStr):
+                    call_joined_parts: list[str] = []
+                    ok = True
+                    for v in first.values:
+                        if isinstance(v, ast.Constant) and isinstance(v.value, str):
+                            call_joined_parts.append(v.value)
+                        else:
+                            ok = False
+                            break
+                    if ok:
+                        modname = "".join(call_joined_parts)
+
+                if modname:
+                    if modname.startswith(root_import):
+                        logger.debug("dynamic import detected (literal/const): %s", modname)
+                        found.add(modname)
+                    lead = modname.split(".")[0]
+                    if lead.startswith(root_import):
+                        logger.debug("dynamic import detected by leading component: %s", modname)
+                        found.add(modname)
     return found
 
 
@@ -193,7 +389,9 @@ def aggregate_sentinels_for_test(
     imports = find_imports_in_file(test_path, root_import, repo_root)
     sentinels: Set[str] = set()
     for mod in sorted(imports):
-        paths = resolve_module_to_paths(mod, repo_root)
+        # Use the member-fallback resolver so dotted member names like
+        # 'pkg.module.Class' will resolve to 'pkg.module' when possible.
+        paths = resolve_module_to_paths_with_member_fallback(mod, repo_root)
         for p in paths:
             try:
                 items = read_sentinels_from_file(p, sentinel_name)

--- a/splurge_test_namer/parser.py
+++ b/splurge_test_namer/parser.py
@@ -16,11 +16,14 @@ from typing import Set, Optional
 
 from splurge_test_namer.util_helpers import (
     safe_file_reader,
+    resolve_module_to_paths,
     resolve_module_to_paths_with_member_fallback,
 )
 from splurge_test_namer.exceptions import FileReadError, SentinelReadError
 
 DOMAINS = ["parser"]
+
+__all__ = ["resolve_module_to_paths"]
 
 
 def _eval_constant_string_binop(node: ast.AST, const_map: Optional[dict[str, str]] = None) -> Optional[str]:

--- a/splurge_test_namer/util_helpers.py
+++ b/splurge_test_namer/util_helpers.py
@@ -10,26 +10,38 @@ License: MIT
 """
 
 from pathlib import Path
+import importlib.util
+import logging
 from splurge_test_namer.exceptions import (
     FileReadError,
     FileWriteError,
     FileRenameError,
     FileGlobError,
 )
-import logging
 
 
 LOGGER = logging.getLogger(__name__)
 
 
-def configure_logging(verbose: bool = False) -> None:
+def configure_logging(verbose: bool = False, debug: bool = False) -> None:
     """Configure module logging level from CLI verbosity.
 
     Args:
-        verbose: When True, sets level to DEBUG; otherwise INFO.
+        verbose: When True, sets level to INFO.
+        debug: When True, sets level to DEBUG and includes filename:lineno.
     """
-    level = logging.DEBUG if verbose else logging.INFO
-    logging.basicConfig(level=level, format="%(levelname)s: %(message)s")
+    # Priority: debug > verbose > default(INFO)
+    if debug:
+        level = logging.DEBUG
+        fmt = "%(levelname)s: %(filename)s:%(lineno)d: %(message)s"
+    elif verbose:
+        level = logging.INFO
+        fmt = "%(levelname)s: %(message)s"
+    else:
+        level = logging.WARNING
+        fmt = "%(levelname)s: %(message)s"
+    # Configure basic logging once (idempotent for simple CLI runs)
+    logging.basicConfig(level=level, format=fmt)
 
 
 DOMAINS = ["utils"]
@@ -157,4 +169,74 @@ def resolve_module_to_paths(module_name: str, repo_root: Path) -> list[Path]:
     if not candidates:
         for p in repo_root.rglob(parts[-1] + ".py"):
             candidates.append(p)
+
+    # If still not found, attempt to resolve via importlib (installed packages
+    # or modules available on sys.path). This avoids importing the module code;
+    # we only inspect the import spec to discover source file locations.
+    if not candidates:
+        try:
+            spec = importlib.util.find_spec(module_name)
+            if spec:
+                # If spec.origin points to a file, add it
+                if spec.origin and spec.origin != "namespace":
+                    candidates.append(Path(spec.origin))
+                # If it's a package, prefer __init__.py inside submodule_search_locations
+                if spec.submodule_search_locations:
+                    for loc in spec.submodule_search_locations:
+                        init = Path(loc) / "__init__.py"
+                        if init.exists():
+                            candidates.append(init)
+        except Exception:
+            # Be conservative — silently ignore resolution failures
+            pass
+
+    # Final fallback: search the working directory for a file that matches the
+    # dotted module path. This helps in monorepo or workspace layouts where the
+    # package might not be under the provided repo_root but is present in the
+    # workspace.
+    if not candidates:
+        try:
+            cwd = Path.cwd()
+            file_candidate = cwd.joinpath(*parts).with_suffix(".py")
+            if file_candidate.exists():
+                candidates.append(file_candidate)
+            else:
+                # as a last resort, search for any file ending with the module name
+                for p in cwd.rglob(parts[-1] + ".py"):
+                    candidates.append(p)
+        except Exception:
+            pass
+
+    # Log resolution outcome for debugging
+    try:
+        logger = logging.getLogger(__name__)
+        if candidates:
+            logger.debug(
+                "resolve_module_to_paths: module '%s' resolved to %s", module_name, [str(p) for p in candidates]
+            )
+        else:
+            logger.debug("resolve_module_to_paths: module '%s' not found under repo_root or sys.path", module_name)
+    except Exception:
+        # Keep resolver robust even if logging fails
+        pass
+
     return candidates
+
+
+def resolve_module_to_paths_with_member_fallback(module_name: str, repo_root: Path) -> list[Path]:
+    """Resolve module paths, with fallback to strip trailing attributes.
+
+    When callers present dotted names that include a class or attribute
+    (e.g. 'pkg.module.Class'), try progressively stripping the last component
+    and re-resolving until a file is found or only the top-level package
+    remains.
+    """
+    base = module_name
+    while base:
+        paths = resolve_module_to_paths(base, repo_root)
+        if paths:
+            return paths
+        if "." not in base:
+            break
+        base = base.rsplit(".", 1)[0]
+    return []

--- a/tests/e2e/test_cli_e2e.py
+++ b/tests/e2e/test_cli_e2e.py
@@ -45,12 +45,12 @@ def test_e2e_cli_dry_and_apply(tmp_path):
     b.write_text("DOMAINS = ['alpha']\n")
 
     # Dry-run: expect proposals printed
-    code, out, err = run_cli(["--root", str(tests), "--repo-root", str(repo)], cwd=repo)
+    code, out, err = run_cli(["--test-root", str(tests), "--repo-root", str(repo)], cwd=repo)
     assert code == 0
     assert "DRY RUN" in out
 
     # Apply with force
-    code2, out2, err2 = run_cli(["--root", str(tests), "--repo-root", str(repo), "--apply", "--force"], cwd=repo)
+    code2, out2, err2 = run_cli(["--test-root", str(tests), "--repo-root", str(repo), "--apply", "--force"], cwd=repo)
     assert code2 == 0
 
     # verify that target files exist and original files no longer exist

--- a/tests/unit/test_cli_0001.py
+++ b/tests/unit/test_cli_0001.py
@@ -12,7 +12,7 @@ def run_main_with_args(args, monkeypatch):
 def test_main_invalid_root(monkeypatch, tmp_path):
     # point to a non-existent root
     with pytest.raises(SystemExit):
-        run_main_with_args(["--root", str(tmp_path / "nope")], monkeypatch)
+        run_main_with_args(["--test-root", str(tmp_path / "nope")], monkeypatch)
 
 
 def test_main_invalid_sentinel(monkeypatch, tmp_path):
@@ -20,14 +20,14 @@ def test_main_invalid_sentinel(monkeypatch, tmp_path):
     tests_root = tmp_path / "tests"
     tests_root.mkdir()
     with pytest.raises(SystemExit):
-        run_main_with_args(["--root", str(tests_root), "--sentinel", "1BAD"], monkeypatch)
+        run_main_with_args(["--test-root", str(tests_root), "--sentinel", "1BAD"], monkeypatch)
 
 
 def test_main_invalid_root_import(monkeypatch, tmp_path):
     tests_root = tmp_path / "tests"
     tests_root.mkdir()
     with pytest.raises(SystemExit):
-        run_main_with_args(["--root", str(tests_root), "--root-import", "pkg..mod"], monkeypatch)
+        run_main_with_args(["--test-root", str(tests_root), "--import-root", "pkg..mod"], monkeypatch)
 
 
 def test_main_repo_root_not_dir(monkeypatch, tmp_path):
@@ -35,7 +35,7 @@ def test_main_repo_root_not_dir(monkeypatch, tmp_path):
     tests_root.mkdir()
     # pass a repo_root that doesn't exist
     with pytest.raises(SystemExit):
-        run_main_with_args(["--root", str(tests_root), "--repo-root", str(tmp_path / "nope")], monkeypatch)
+        run_main_with_args(["--test-root", str(tests_root), "--repo-root", str(tmp_path / "nope")], monkeypatch)
 
 
 def test_main_dry_run_calls_show_and_returns(monkeypatch, tmp_path):
@@ -53,7 +53,7 @@ def test_main_dry_run_calls_show_and_returns(monkeypatch, tmp_path):
 
     monkeypatch.setattr(cli, "show_dry_run", fake_show)
     # run without --apply (dry run)
-    run_main_with_args(["--root", str(tests_root)], monkeypatch)
+    run_main_with_args(["--test-root", str(tests_root)], monkeypatch)
     assert "count" in called
 
 
@@ -69,5 +69,5 @@ def test_main_apply_calls_apply_renames(monkeypatch, tmp_path):
         called["force"] = force
 
     monkeypatch.setattr(cli, "apply_renames", fake_apply)
-    run_main_with_args(["--root", str(tests_root), "--apply", "--force"], monkeypatch)
+    run_main_with_args(["--test-root", str(tests_root), "--apply", "--force"], monkeypatch)
     assert called.get("force") is True

--- a/tests/unit/test_cli_0004.py
+++ b/tests/unit/test_cli_0004.py
@@ -35,7 +35,7 @@ def test_cli_dry_run(tmp_path, capsys, monkeypatch):
     prop = orig.with_name("test_misc_0001.py")
     proposals = [(orig, prop)]
 
-    captured, applied = run_cli_with_args(["--root", str(tmp_path / "tests")], capsys, monkeypatch, proposals)
+    captured, applied = run_cli_with_args(["--test-root", str(tmp_path / "tests")], capsys, monkeypatch, proposals)
     assert "DRY RUN - original | proposed" in captured.out
     assert applied == {}
 
@@ -48,6 +48,6 @@ def test_cli_apply_calls_apply_renames(tmp_path, capsys, monkeypatch):
     proposals = [(orig, prop)]
 
     captured, applied = run_cli_with_args(
-        ["--root", str(tmp_path / "tests"), "--apply"], capsys, monkeypatch, proposals
+        ["--test-root", str(tmp_path / "tests"), "--apply"], capsys, monkeypatch, proposals
     )
     assert applied.get("called") is True

--- a/tests/unit/test_cli_0005.py
+++ b/tests/unit/test_cli_0005.py
@@ -34,7 +34,7 @@ def test_cli_accepts_empty_root_import(tmp_path):
     f = tests / "test_one.py"
     f.write_text("DOMAINS = ['alpha']\n")
 
-    # Pass an explicit empty string for --root-import; CLI should normalize it to None
-    code, out, err = run_cli(["--root", str(tests), "--repo-root", str(repo), "--root-import", ""], cwd=repo)
+    # Pass an explicit empty string for --import-root; CLI should normalize it to None
+    code, out, err = run_cli(["--test-root", str(tests), "--repo-root", str(repo), "--import-root", ""], cwd=repo)
     assert code == 0
     assert "DRY RUN" in out

--- a/tests/unit/test_namer_exclude_0001.py
+++ b/tests/unit/test_namer_exclude_0001.py
@@ -1,0 +1,33 @@
+from pathlib import Path
+
+from splurge_test_namer.namer import build_proposals
+
+
+def test_build_proposals_respects_excludes(tmp_path: Path) -> None:
+    """build_proposals should not include files under excluded subfolders.
+
+    We create a small tests/ tree with an included and an excluded folder, each
+    containing a test_*.py file with a DOMAINS sentinel. When calling
+    build_proposals with the excluded folder name, proposals must not contain
+    origins from that folder.
+    """
+    root = tmp_path / "tests"
+    included = root / "included"
+    excluded = root / "excluded_dir"
+    included.mkdir(parents=True)
+    excluded.mkdir(parents=True)
+
+    incl_file = included / "test_included.py"
+    excl_file = excluded / "test_excluded.py"
+
+    # simple sentinel declarations
+    incl_file.write_text("DOMAINS = ['INCLUDED']\n")
+    excl_file.write_text("DOMAINS = ['EXCLUDED']\n")
+
+    proposals = build_proposals(root, "DOMAINS", excludes=["excluded_dir"])
+
+    # ensure we have at least one proposal (the included file)
+    assert any(p[0].name == "test_included.py" for p in proposals)
+
+    # ensure none of the proposals originate from the excluded directory
+    assert not any("excluded_dir" in (str(p[0].parts)) for p in proposals)

--- a/tests/unit/test_parser_dynamic_imports_0001.py
+++ b/tests/unit/test_parser_dynamic_imports_0001.py
@@ -1,0 +1,38 @@
+from pathlib import Path
+
+from splurge_test_namer.parser import find_imports_in_file
+
+
+def _write_and_find(src: str, tmp_path: Path, root_import: str):
+    p = tmp_path / "tests" / "test_dyn.py"
+    p.parent.mkdir(parents=True)
+    p.write_text(src)
+    return find_imports_in_file(p, root_import, repo_root=None)
+
+
+def test_importlib_import_module_literal(tmp_path: Path):
+    src = 'import importlib\nimportlib.import_module("splurge_lazyframe_compare.main")\n'
+    found = _write_and_find(src, tmp_path, "splurge_lazyframe_compare")
+    assert "splurge_lazyframe_compare.main" in found
+
+
+def test_from_importlib_import_module_literal(tmp_path: Path):
+    src = 'from importlib import import_module\nimport_module("splurge_lazyframe_compare.main")\n'
+    found = _write_and_find(src, tmp_path, "splurge_lazyframe_compare")
+    assert "splurge_lazyframe_compare.main" in found
+
+
+def test_dunder_import_literal(tmp_path: Path):
+    src = '__import__("splurge_lazyframe_compare.main")\n'
+    found = _write_and_find(src, tmp_path, "splurge_lazyframe_compare")
+    assert "splurge_lazyframe_compare.main" in found
+
+
+def test_sourcefileloader_load_module_literal(tmp_path: Path):
+    src = (
+        "import importlib.machinery\n"
+        'loader = importlib.machinery.SourceFileLoader("mod", "/tmp/mod.py")\n'
+        'loader.load_module("splurge_lazyframe_compare.main")\n'
+    )
+    found = _write_and_find(src, tmp_path, "splurge_lazyframe_compare")
+    assert "splurge_lazyframe_compare.main" in found

--- a/tests/unit/test_parser_relative_imports_0001.py
+++ b/tests/unit/test_parser_relative_imports_0001.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+
+from splurge_test_namer.parser import find_imports_in_file
+
+
+def test_relative_import_resolution(tmp_path: Path):
+    # repo/pkg/sub/__init__.py and repo/pkg/sub/mod.py
+    repo = tmp_path / "repo"
+    sub = repo / "pkg" / "sub"
+    sub.mkdir(parents=True)
+    (repo / "pkg" / "__init__.py").write_text("# pkg init\n")
+    (sub / "__init__.py").write_text("DOMAINS = ['SUB']\n")
+    (sub / "mod.py").write_text("DOMAINS = ['MOD']\n")
+
+    # Create a test file inside repo/pkg/tests/test_rel.py to simulate base module
+    test_dir = repo / "pkg" / "tests"
+    test_dir.mkdir(parents=True)
+    t = test_dir / "test_rel.py"
+    # from ..sub import mod  (level=2 -> climb up two parts from pkg.tests -> pkg)
+    t.write_text("from ..sub import mod\n")
+
+    found = find_imports_in_file(t, "pkg", repo_root=repo)
+    assert "pkg.sub.mod" in found or "pkg.sub" in found

--- a/tests/unit/test_parser_star_expansion_0001.py
+++ b/tests/unit/test_parser_star_expansion_0001.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+
+from splurge_test_namer.parser import find_imports_in_file
+
+
+def test_star_import_expansion(tmp_path: Path):
+    # Create package structure: pkg/__init__.py, pkg/a.py, pkg/b.py
+    repo = tmp_path / "repo"
+    pkg = repo / "pkg"
+    pkg.mkdir(parents=True)
+    (pkg / "__init__.py").write_text("# init\n")
+    (pkg / "a.py").write_text("DOMAINS = ['A']\n")
+    (pkg / "b.py").write_text("DOMAINS = ['B']\n")
+
+    # Create test module that does 'from pkg import *'
+    tests_dir = tmp_path / "tests"
+    tests_dir.mkdir()
+    t = tests_dir / "test_star.py"
+    t.write_text("from pkg import *\n")
+
+    found = find_imports_in_file(t, "pkg", repo_root=repo)
+    # Expect expansion to include pkg.a and pkg.b
+    assert "pkg.a" in found
+    assert "pkg.b" in found

--- a/tests/unit/test_parser_static_and_dynamic_0001.py
+++ b/tests/unit/test_parser_static_and_dynamic_0001.py
@@ -1,0 +1,40 @@
+from pathlib import Path
+
+from splurge_test_namer.parser import find_imports_in_file
+
+
+def test_static_and_dynamic_imports(tmp_path: Path):
+    src = (
+        "import splurge_lazyframe_compare.submod\n"
+        "import importlib\n"
+        "importlib.import_module('splurge_lazyframe_compare.main')\n"
+        "from importlib import import_module\n"
+        "import_module('splurge_lazyframe_compare.helper')\n"
+        "__import__('splurge_lazyframe_compare.dunder')\n"
+        "import importlib.machinery\n"
+        "loader = importlib.machinery.SourceFileLoader('mod', '/tmp/mod.py')\n"
+        "loader.load_module('splurge_lazyframe_compare.loader')\n"
+        "NAME = 'splurge_lazyframe_compare.const'\n"
+        "import_module(NAME)\n"
+        "A = 'splurge_lazyframe_compare'\n"
+        "B = '.concat'\n"
+        "C = A + B\n"
+        "import_module(C)\n"
+        "F = f'splurge_lazyframe_compare.fstr'\n"
+        "import_module(F)\n"
+    )
+    p = tmp_path / "t.py"
+    p.write_text(src)
+    found = find_imports_in_file(p, "splurge_lazyframe_compare", repo_root=None)
+    # Expected modules
+    expected = {
+        "splurge_lazyframe_compare.submod",
+        "splurge_lazyframe_compare.main",
+        "splurge_lazyframe_compare.helper",
+        "splurge_lazyframe_compare.dunder",
+        "splurge_lazyframe_compare.loader",
+        "splurge_lazyframe_compare.const",
+        "splurge_lazyframe_compare.concat",
+        "splurge_lazyframe_compare.fstr",
+    }
+    assert expected.issubset(found)

--- a/tools/rename_tests_by_sentinels.py
+++ b/tools/rename_tests_by_sentinels.py
@@ -1,7 +1,7 @@
 """Rename test modules based on their <sentinel> metadata.
 
 Usage:
-  python tools/rename_tests_by_sentinels.py [--root tests] [--apply] [--sentinel DOMAINS]
+    python tools/rename_tests_by_sentinels.py [--test-root tests] [--apply] [--sentinel DOMAINS]
 
 Default is a dry-run which prints "original | proposed". When --apply is used
 the script will perform os.rename and print "[original] -> [new]" for each
@@ -126,7 +126,7 @@ def apply_renames(proposals: list[tuple[Path, Path]]) -> None:
 
 def parse_args() -> argparse.Namespace:
     p = argparse.ArgumentParser(description="Rename test modules based on <sentinel> metadata")
-    p.add_argument("--root", default="tests", help="Root tests directory to scan")
+    p.add_argument("--test-root", dest="test_root", default="tests", help="Root tests directory to scan")
     p.add_argument("--apply", action="store_true", help="Apply the renames (default is dry-run)")
     p.add_argument("--sentinel", default="DOMAINS", help="Module-level sentinel list to read (default: DOMAINS)")
     return p.parse_args()
@@ -134,7 +134,7 @@ def parse_args() -> argparse.Namespace:
 
 def main() -> None:
     args = parse_args()
-    root = Path(args.root)
+    root = Path(args.test_root)
     sentinel = args.sentinel
     if not root.exists():
         print(f"Test root not found: {root}")


### PR DESCRIPTION
This pull request updates the CLI interface and internal logic of the test module renamer for improved usability, flexibility, and compatibility. The main changes include renaming several CLI flags for clarity, adding new options for excluding directories and controlling logging verbosity, enhancing dynamic import detection, and making the CLI backward-compatible with older test stubs. Additionally, a console script entry point is added for easier command-line usage.

**CLI flag renaming and documentation updates:**
- Renamed the `--root` CLI flag to `--test-root` throughout the codebase and documentation for clarity. Similarly, renamed `--root-import` to `--import-root`. All help texts, usage examples, and docs were updated to match. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL4-R4) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L24-R33) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L96-R96) [[4]](diffhunk://#diff-eaaece26412e44100bfab3b49fb7df146af125ec89ffc8e46fd66a90182e6860L35-R38) [[5]](diffhunk://#diff-eaaece26412e44100bfab3b49fb7df146af125ec89ffc8e46fd66a90182e6860L100-R100) [[6]](diffhunk://#diff-e042b185b2d7d96522da40ba09530a3ee0fee3e87ca635258f208131b4848787L92-R92) [[7]](diffhunk://#diff-99de14c74010939cceafd75820828485c1b82ce2506cfdac25a0b101cd8c6b77L33-R67) [[8]](diffhunk://#diff-99de14c74010939cceafd75820828485c1b82ce2506cfdac25a0b101cd8c6b77L90-R122)

**New CLI options and compatibility improvements:**
- Added `--exclude` to allow users to specify a semicolon-delimited list of subfolders to skip during scanning (e.g., `__pycache__`, `venv`). [[1]](diffhunk://#diff-99de14c74010939cceafd75820828485c1b82ce2506cfdac25a0b101cd8c6b77L33-R67) [[2]](diffhunk://#diff-99de14c74010939cceafd75820828485c1b82ce2506cfdac25a0b101cd8c6b77R143-R161) [[3]](diffhunk://#diff-d31a3d47334f204e34553a6b60c68506b70f463f0d3eb16cb7a050dc645d1c7aR52) [[4]](diffhunk://#diff-d31a3d47334f204e34553a6b60c68506b70f463f0d3eb16cb7a050dc645d1c7aR65-R83)
- Added `--debug` flag for most verbose logging, in addition to `--verbose`. Logging setup now prioritizes `--debug` if both are set. [[1]](diffhunk://#diff-99de14c74010939cceafd75820828485c1b82ce2506cfdac25a0b101cd8c6b77L33-R67) [[2]](diffhunk://#diff-99de14c74010939cceafd75820828485c1b82ce2506cfdac25a0b101cd8c6b77L90-R122)
- The CLI now checks if the `build_proposals` function supports the new `excludes` argument and only passes it if compatible, ensuring backward compatibility with older test setups.

**Dynamic import and parsing enhancements:**
- Improved import scanning in `parser.py` to recognize dynamic imports using `importlib.import_module`, `__import__`, and loaders created via `importlib.machinery.SourceFileLoader`, including cases where the module name is constructed via string concatenation or f-strings. [[1]](diffhunk://#diff-2a611e94fa15e2bc34bb77d2784659875ec5f04ab5c8db3b99ac56a19eddbe47R12-R51) [[2]](diffhunk://#diff-2a611e94fa15e2bc34bb77d2784659875ec5f04ab5c8db3b99ac56a19eddbe47R128-R134) [[3]](diffhunk://#diff-2a611e94fa15e2bc34bb77d2784659875ec5f04ab5c8db3b99ac56a19eddbe47R145-R201)
- Added helper function `_eval_constant_string_binop` to evaluate simple string concatenations in AST nodes, supporting more robust detection of dynamically built import names.

**Project packaging and setup improvements:**
- Added a console script entry point (`splurge-test-namer`) in `pyproject.toml` for easier CLI invocation.
- Updated setuptools configuration to exclude `tmp_scan` from package discovery.

**Bug fixes and robustness:**
- Enhanced fallback logic in `build_proposals` to ensure that if import-based sentinel aggregation fails, the tool falls back to in-file sentinel assignments, preventing loss of sentinel information.
- Improved error handling and logging throughout the CLI and parser for better debugging and user feedback. [[1]](diffhunk://#diff-d31a3d47334f204e34553a6b60c68506b70f463f0d3eb16cb7a050dc645d1c7aR16) [[2]](diffhunk://#diff-2a611e94fa15e2bc34bb77d2784659875ec5f04ab5c8db3b99ac56a19eddbe47R12-R51)

These changes collectively make the tool more user-friendly, robust, and extensible for future enhancements.